### PR TITLE
Fixed #89.

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1489,8 +1489,7 @@ class defer_event {
   }
 
  public:
-  defer_event(defer_event &&) = default;
-  defer_event(const defer_event &) = delete;
+  defer_event(defer_event &&other) : defer_event(other) { other.id = -1; }
   defer_event &operator=(const defer_event &) = delete;
   template <class T>
   defer_event(T object) {
@@ -1498,11 +1497,14 @@ class defer_event {
     dtor = &dtor_impl<T>;
     new (&data) T(static_cast<T &&>(object));
   }
-  ~defer_event() { dtor(data); }
+  ~defer_event() {
+    if (id != -1) dtor(data);
+  }
   alignas(alignment) aux::byte data[size];
   int id = -1;
 
  private:
+  defer_event(const defer_event &) = default;
   void (*dtor)(aux::byte *);
 };
 struct defer : action_base {

--- a/include/boost/sml/front/actions/defer.hpp
+++ b/include/boost/sml/front/actions/defer.hpp
@@ -25,8 +25,10 @@ class defer_event {
   }
 
  public:
-  defer_event(defer_event &&) = default;
-  defer_event(const defer_event &) = delete;
+  defer_event(defer_event && other):defer_event(other) {
+    other.id = -1;
+  }
+
   defer_event &operator=(const defer_event &) = delete;
 
   template <class T>
@@ -36,12 +38,13 @@ class defer_event {
     new (&data) T(static_cast<T &&>(object));
   }
 
-  ~defer_event() { dtor(data); }
+  ~defer_event() { if (id != -1) dtor(data); }
 
   alignas(alignment) aux::byte data[size];
   int id = -1;
 
  private:
+  defer_event(const defer_event &) = default;
   void (*dtor)(aux::byte *);
 };
 


### PR DESCRIPTION
Moved from defer_event no longer call the destructor of T.
This fix assumes that id '-1' is never used as a valid id.