### PR TITLE
[front-end] Fix #97 Guards and logical expressions.

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1445,7 +1445,7 @@ class and_ : operator_base {
   auto for_all(const aux::index_sequence<Ns...> &, const TEvent &event, TSM &sm, TDeps &deps, TSubs &subs) {
     auto result = true;
     (void)aux::swallow{
-        0, (call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
+        0, (result && call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
                 ? result
                 : (result = false))...};
     return result;
@@ -1466,7 +1466,7 @@ class or_ : operator_base {
   auto for_all(const aux::index_sequence<Ns...> &, const TEvent &event, TSM &sm, TDeps &deps, TSubs &subs) {
     auto result = false;
     (void)aux::swallow{
-        0, (call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
+        0, (result || call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
                 ? (result = true)
                 : result)...};
     return result;

--- a/include/boost/sml/front/operators.hpp
+++ b/include/boost/sml/front/operators.hpp
@@ -187,7 +187,7 @@ class and_ : operator_base {
   auto for_all(const aux::index_sequence<Ns...> &, const TEvent &event, TSM &sm, TDeps &deps, TSubs &subs) {
     auto result = true;
     (void)aux::swallow{
-        0, (call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
+        0, (result && call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
                 ? result
                 : (result = false))...};
     return result;
@@ -211,7 +211,7 @@ class or_ : operator_base {
   auto for_all(const aux::index_sequence<Ns...> &, const TEvent &event, TSM &sm, TDeps &deps, TSubs &subs) {
     auto result = false;
     (void)aux::swallow{
-        0, (call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
+        0, (result || call<TEvent, args_t<Ts, TEvent>, typename TSM::logger_t>::execute(aux::get_by_id<Ns>(&g), event, sm, deps, subs)
                 ? (result = true)
                 : result)...};
     return result;


### PR DESCRIPTION
Logical expressions of guards are now handled as expected and known from
C++:
* In AND logical expressions, the first guard that returns false
  prevents the remaining guards from being executed.
* In OR logical expressions, the first guard that returns true prevents
  the remaining guards from being executed.

This fixes #97 .