### PR TITLE
Fix #107. Add support for C++17 noexcept.

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -171,6 +171,24 @@ template <class R, class T, class... TArgs>
 struct function_traits<R (T::*)(TArgs...) const> {
   using args = type_list<TArgs...>;
 };
+#if __cplusplus > 201402L
+template <class R, class... TArgs>
+struct function_traits<R (*)(TArgs...) noexcept> {
+  using args = type_list<TArgs...>;
+};
+template <class R, class... TArgs>
+struct function_traits<R(TArgs...) noexcept> {
+  using args = type_list<TArgs...>;
+};
+template <class R, class T, class... TArgs>
+struct function_traits<R (T::*)(TArgs...) noexcept> {
+  using args = type_list<TArgs...>;
+};
+template <class R, class T, class... TArgs>
+struct function_traits<R (T::*)(TArgs...) const noexcept> {
+  using args = type_list<TArgs...>;
+};
+#endif
 template <class T>
 using function_traits_t = typename function_traits<T>::args;
 }

--- a/include/boost/sml/aux_/type_traits.hpp
+++ b/include/boost/sml/aux_/type_traits.hpp
@@ -139,6 +139,24 @@ template <class R, class T, class... TArgs>
 struct function_traits<R (T::*)(TArgs...) const> {
   using args = type_list<TArgs...>;
 };
+#if __cplusplus > 201402L
+template <class R, class... TArgs>
+struct function_traits<R (*)(TArgs...) noexcept> {
+  using args = type_list<TArgs...>;
+};
+template <class R, class... TArgs>
+struct function_traits<R(TArgs...) noexcept> {
+  using args = type_list<TArgs...>;
+};
+template <class R, class T, class... TArgs>
+struct function_traits<R (T::*)(TArgs...) noexcept> {
+  using args = type_list<TArgs...>;
+};
+template <class R, class T, class... TArgs>
+struct function_traits<R (T::*)(TArgs...) const noexcept> {
+  using args = type_list<TArgs...>;
+};
+#endif
 template <class T>
 using function_traits_t = typename function_traits<T>::args;
 


### PR DESCRIPTION
With C++17 `noexcept` becomes part of a function's signature (if present).

Therefore, template-specializations which try to match a function signature must also consider the 'noexcept' keyword now.

This fixes #107.