### PR TITLE
make dispatch table could add SM with rebind_policies

### DIFF
--- a/include/boost/sml/utility/dispatch_table.hpp
+++ b/include/boost/sml/utility/dispatch_table.hpp
@@ -93,12 +93,12 @@ template <int N, class T>
 using get_event_t = typename get_event<N, T>::type;
 
 template <class TEvent, int EventRangeBegin, class SM, int... Ns>
-auto make_dispatch_table(sm<SM> &fsm, const aux::index_sequence<Ns...> &) {
-  using events_ids_t = aux::apply_t<event_id, typename sm<SM>::events>;
+auto make_dispatch_table(SM &fsm, const aux::index_sequence<Ns...> &) {
+  using events_ids_t = aux::apply_t<event_id, typename SM::events>;
   return [&](const TEvent &e, int id) {
-    using dispatch_table_t = void (*)(sm<SM> &, const TEvent &);
+    using dispatch_table_t = void (*)(SM &, const TEvent &);
     const static dispatch_table_t dispatch_table[sizeof...(Ns) ? sizeof...(Ns) : 1] = {
-        &get_event_t<Ns + EventRangeBegin, events_ids_t>::template execute<sm<SM>, TEvent>...};
+        &get_event_t<Ns + EventRangeBegin, events_ids_t>::template execute<SM, TEvent>...};
     dispatch_table[id - EventRangeBegin](fsm, e);
   };
 }
@@ -119,8 +119,8 @@ template <int... Ids>
 using id = id_impl<Ids...>;
 
 template <class TEvent, int EventRangeBegin, int EventRangeEnd, class SM,
-          __BOOST_SML_REQUIRES(concepts::dispatchable<TEvent, typename sm<SM>::events>::value)>
-auto make_dispatch_table(sm<SM> &fsm) {
+          __BOOST_SML_REQUIRES(concepts::dispatchable<TEvent, typename SM::events>::value)>
+auto make_dispatch_table(SM &fsm) {
   static_assert(EventRangeEnd - EventRangeBegin > 0, "Event ids range difference has to be greater than 0");
   return detail::make_dispatch_table<TEvent, EventRangeBegin>(fsm,
                                                               aux::make_index_sequence<EventRangeEnd - EventRangeBegin + 1>{});

--- a/test/ft/dispatch_table.cpp
+++ b/test/ft/dispatch_table.cpp
@@ -172,7 +172,8 @@ test dispatch_sm_with_rebind_policies  = [] {
   };
 
   {
-    sml::sm<c, sml::logger<my_logger>> sm;
+    my_logger logger;
+    sml::sm<c, sml::logger<my_logger>> sm{ logger };
     expect(sm.is(idle));
     auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
     runtime_event event{4};
@@ -181,7 +182,8 @@ test dispatch_sm_with_rebind_policies  = [] {
   }
 
   {
-    sml::sm<c> sm;
+    my_logger logger;
+    sml::sm<c, sml::logger<my_logger>> sm{ logger };
     expect(sm.is(idle));
     auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
     runtime_event event{5};

--- a/test/ft/dispatch_table.cpp
+++ b/test/ft/dispatch_table.cpp
@@ -134,6 +134,62 @@ test dispatch_runtime_event_dynamic_id = [] {
   }
 };
 
+test dispatch_sm_with_rebind_policies  = [] {
+  struct my_logger {
+    template <class SM, class TEvent>
+    void log_process_event(const TEvent&) {
+      printf("[%s][process_event] %s\n", sml::aux::get_type_name<SM>(), sml::aux::get_type_name<TEvent>());
+    }
+
+    template <class SM, class TGuard, class TEvent>
+    void log_guard(const TGuard&, const TEvent&, bool result) {
+      printf("[%s][guard] %s %s %s\n", sml::aux::get_type_name<SM>(), sml::aux::get_type_name<TGuard>(),
+             sml::aux::get_type_name<TEvent>(), (result ? "[OK]" : "[Reject]"));
+    }
+
+    template <class SM, class TAction, class TEvent>
+    void log_action(const TAction&, const TEvent&) {
+      printf("[%s][action] %s %s\n", sml::aux::get_type_name<SM>(), sml::aux::get_type_name<TAction>(),
+             sml::aux::get_type_name<TEvent>());
+    }
+
+    template <class SM, class TSrcState, class TDstState>
+    void log_state_change(const TSrcState& src, const TDstState& dst) {
+      printf("[%s][transition] %s -> %s\n", sml::aux::get_type_name<SM>(), src.c_str(), dst.c_str());
+    }
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+
+      // clang-format off
+      return make_transition_table(
+         *idle + event<event4_5> = X
+      );
+      // clang-format on
+    }
+  };
+
+  {
+    sml::sm<c, sml::logger<my_logger>> sm;
+    expect(sm.is(idle));
+    auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
+    runtime_event event{4};
+    dispatcher(event, event.id);
+    expect(sm.is(sml::X));
+  }
+
+  {
+    sml::sm<c> sm;
+    expect(sm.is(idle));
+    auto dispatcher = sml::utility::make_dispatch_table<runtime_event, 1 /*min*/, 10 /*max*/>(sm);
+    runtime_event event{5};
+    dispatcher(event, event.id);
+    expect(sm.is(sml::X));
+  }
+};
+
 test dispatch_runtime_event_sub_sm = [] {
   static auto in_sub = 0;
 


### PR DESCRIPTION
In the past we cannot define a dispatch table such as following:
```
auto dispatch_event =
    sml::utility::make_dispatch_table<OperationalLogic::emptyEvent, 0 /*min*/,
                                      20 /*max*/, StateMachine>(sm);
```
where StateMachine have rebind policies, such as:
```
sml::sm<logging, sml::logger<my_logger>> sm{logger};
```

It is because the dispatch table only allow the SM have one template input.

This patch is going to let SM with rebind_policies could have dispatch table