### PR TITLE
[front-end] Fix #76 Process event at root-SM if dispatched from sub-SM.

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1311,13 +1311,16 @@ struct composable : aux::is<aux::pool, decltype(composable_impl<T>(0))> {};
 namespace front {
 struct operator_base {};
 struct action_base {};
+template <class TRootSM, class... TSubSMs>
+TRootSM get_root_sm_impl(aux::pool<TRootSM, TSubSMs...> *);
+template <class TSubs>
+using get_root_sm_t = decltype(get_root_sm_impl((TSubs *)0));
 template <class TSM, class TDeps, class TSubs>
 struct sm_ref {
   template <class TEvent>
   auto process_event(const TEvent &event) {
-    return sm.process_event(event, deps, subs);
+    return aux::get<get_root_sm_t<TSubs>>(subs).process_event(event, deps, subs);
   }
-  TSM &sm;
   TDeps &deps;
   TSubs &subs;
 };
@@ -1440,8 +1443,8 @@ struct call<TEvent, aux::type_list<action_base>, TLogger> {
 template <class TEvent, class... Ts>
 struct call<TEvent, aux::type_list<Ts...>, back::no_policy> {
   template <class T, class TSM, class TDeps, class TSubs>
-  static auto execute(T object, const TEvent &event, TSM &sm, TDeps &deps, TSubs &subs) {
-    sm_ref<TSM, TDeps, TSubs> sm_ref{sm, deps, subs};
+  static auto execute(T object, const TEvent &event, TSM &, TDeps &deps, TSubs &subs) {
+    sm_ref<TSM, TDeps, TSubs> sm_ref{deps, subs};
     return object(get_arg(aux::type<Ts>{}, event, sm_ref, deps)...);
   }
 };
@@ -1449,20 +1452,20 @@ template <class TEvent, class... Ts, class TLogger>
 struct call<TEvent, aux::type_list<Ts...>, TLogger> {
   template <class T, class TSM, class TDeps, class TSubs>
   static auto execute(T object, const TEvent &event, TSM &sm, TDeps &deps, TSubs &subs) {
-    sm_ref<TSM, TDeps, TSubs> sm_ref{sm, deps, subs};
+    sm_ref<TSM, TDeps, TSubs> sm_ref{deps, subs};
     using result_type = decltype(object(get_arg(aux::type<Ts>{}, event, sm_ref, deps)...));
     return execute_impl<typename TSM::sm_t>(aux::type<result_type>{}, object, event, sm, deps, subs);
   }
   template <class TSM, class T, class SM, class TDeps, class TSubs>
-  static auto execute_impl(const aux::type<bool> &, T object, const TEvent &event, SM &sm, TDeps &deps, TSubs &subs) {
-    sm_ref<SM, TDeps, TSubs> sm_ref{sm, deps, subs};
+  static auto execute_impl(const aux::type<bool> &, T object, const TEvent &event, SM &, TDeps &deps, TSubs &subs) {
+    sm_ref<SM, TDeps, TSubs> sm_ref{deps, subs};
     const auto result = object(get_arg(aux::type<Ts>{}, event, sm_ref, deps)...);
     back::log_guard<TSM>(aux::type<TLogger>{}, deps, object, event, result);
     return result;
   }
   template <class TSM, class T, class SM, class TDeps, class TSubs>
-  static auto execute_impl(const aux::type<void> &, T object, const TEvent &event, SM &sm, TDeps &deps, TSubs &subs) {
-    sm_ref<SM, TDeps, TSubs> sm_ref{sm, deps, subs};
+  static auto execute_impl(const aux::type<void> &, T object, const TEvent &event, SM &, TDeps &deps, TSubs &subs) {
+    sm_ref<SM, TDeps, TSubs> sm_ref{deps, subs};
     back::log_action<TSM>(aux::type<TLogger>{}, deps, object, event);
     object(get_arg(aux::type<Ts>{}, event, sm_ref, deps)...);
   }
@@ -1658,8 +1661,8 @@ struct process {
    public:
     explicit process_impl(const TEvent &event) : event(event) {}
     template <class T, class TSM, class TDeps, class TSubs>
-    void operator()(const T &, TSM &sm, TDeps &deps, TSubs &subs) {
-      sm.process_event(event, deps, subs);
+    void operator()(const T &, TSM &, TDeps &deps, TSubs &subs) {
+      aux::get<get_root_sm_t<TSubs>>(subs).process_event(event, deps, subs);
     }
 
    private:

--- a/include/boost/sml/front/actions/process.hpp
+++ b/include/boost/sml/front/actions/process.hpp
@@ -19,8 +19,8 @@ struct process {
     explicit process_impl(const TEvent& event) : event(event) {}
 
     template <class T, class TSM, class TDeps, class TSubs>
-    void operator()(const T&, TSM& sm, TDeps& deps, TSubs& subs) {
-      sm.process_event(event, deps, subs);
+    void operator()(const T&, TSM&, TDeps& deps, TSubs& subs) {
+      aux::get<get_root_sm_t<TSubs>>(subs).process_event(event, deps, subs);
     }
 
    private:

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -17,6 +17,8 @@ struct e3 {};
 
 const auto idle = sml::state<class idle>;
 const auto s1 = sml::state<class s1>;
+const auto s2 = sml::state<class s2>;
+const auto s3 = sml::state<class s3>;
 
 test process_event = [] {
   struct c {
@@ -73,4 +75,118 @@ test process_event_using_injected_sm = [] {
     sm.process_event(e1{});
     expect(sm.is("s3"_s));
   }
+};
+
+test process_event_from_substate = [] {
+  struct sub {
+    auto operator()() const noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *s1 + event<e1> = s2
+        , s2 + event<e2> / process(e3{})
+        , s2 + event<e1> / process(e3{}) = s3
+        , s3 + event<e3> = X
+      );
+      // clang-format on
+    }
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *idle + event<e1> = state<sub>
+        , state<sub> + event<e3> / [this] { a_called++; }
+      );
+      // clang-format on
+    }
+
+    int a_called = 0;
+  };
+
+  c c_;
+  sml::sm<c> sm{c_};
+  expect(sm.is(idle));
+  expect(sm.is<decltype(sml::state<sub>)>(s1));
+
+  sm.process_event(e1{});
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(s1));
+  expect(!c_.a_called);
+
+  sm.process_event(e1{});
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(s2));
+  expect(!c_.a_called);
+
+  sm.process_event(e2{});  // + process(e3{})
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(s2));
+  expect(1 == c_.a_called);
+
+  sm.process_event(e1{});  // + process(e3{})
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(sml::X));
+  expect(1 == c_.a_called);
+};
+
+test process_event_from_substate_using_injected_sm = [] {
+  struct sub {
+    auto operator()() const noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *s1 + event<e1> = s2
+        , s2 + event<e2> / [](auto, auto& sm) {
+                sm.process_event(e3{});
+            }
+        , s2 + event<e1> / [](auto, auto& sm) {
+                sm.process_event(e3{});
+            } = s3
+        , s3 + event<e3> = X
+      );
+      // clang-format on
+    }
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *idle + event<e1> = state<sub>
+        , state<sub> + event<e3> / [this] { a_called++; }
+      );
+      // clang-format on
+    }
+
+    int a_called = 0;
+  };
+
+  c c_;
+  sml::sm<c> sm{c_};
+  expect(sm.is(idle));
+  expect(sm.is<decltype(sml::state<sub>)>(s1));
+
+  sm.process_event(e1{});
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(s1));
+  expect(!c_.a_called);
+
+  sm.process_event(e1{});
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(s2));
+  expect(!c_.a_called);
+
+  sm.process_event(e2{});  // + process_event(e3{})
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(s2));
+  expect(1 == c_.a_called);
+
+  sm.process_event(e1{});  // + process_event(e3{})
+  expect(sm.is(sml::state<sub>));
+  expect(sm.is<decltype(sml::state<sub>)>(sml::X));
+  expect(1 == c_.a_called);
 };


### PR DESCRIPTION
Events dispatched from a substate-machine were only processed within that substate-machine and not in the parent state-machines.

This is fixed now!

Events dispatched from a substate-machine are now processed by the entire state-machine and no longer only in the substate-machine.

If called via `process( event{} )` directly from the transition-table or from within an action via `sm.process_event( event{} )` makes no difference.

---

Note, however, that this fix requires the following observation to always be true:

* `TSubs` always contains all state-machines, the root-SM as well as all sub-SMs.
* The first entry in `TSubs` is always the root-SM.

I assume, this is always the case but maybe someone knows an obscure situation in which this is not true. Then please speak up!

This fixes #76 .