### PR TITLE
Fixed several warnings (which were treated as errors).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,15 @@ CXX?=clang++
 ifneq (, $(findstring clang++, $(CXX)))
 	CXXFLAGS+=-std=c++1y -Wall -Wextra -Werror -pedantic -pedantic-errors -I include -I .
 	INCLUDE_TEST=-include test/common/test.hpp
+	DISABLE_EXCEPTIONS=-fno-exceptions
 else ifneq (, $(findstring g++, $(CXX)))
 	CXXFLAGS+=-std=c++1y -Wall -Wextra -Werror -pedantic -pedantic-errors -I include -I .
 	INCLUDE_TEST=-include test/common/test.hpp
+	DISABLE_EXCEPTIONS=-fno-exceptions
 else
 	CXXFLAGS+=-EHsc -W4 -WX -I include -I .
 	INCLUDE_TEST=-FI test/common/test.hpp
+	DISABLE_EXCEPTIONS=
 endif
 VALGRIND:=valgrind --leak-check=full --error-exitcode=1
 DRMEMORY:=drmemory -light -batch -exit_code_if_errors 1 --
@@ -36,28 +39,28 @@ check: style
 test: $(patsubst %.cpp, %.out, $(wildcard test/ft/*.cpp test/ft/errors/*.cpp test/ut/*.cpp))
 
 test/ut/%.out:
-	$(CXX) test/ut/$*.cpp $(CXXFLAGS) -fno-exceptions $($(COVERAGE)) $(INCLUDE_TEST) -o test/ut/$*.out	&& $($(MEMCHECK)) test/ut/$*.out
+	$(CXX) test/ut/$*.cpp $(CXXFLAGS) $(DISABLE_EXCEPTIONS) $($(COVERAGE)) $(INCLUDE_TEST) -o test/ut/$*.out && $($(MEMCHECK)) test/ut/$*.out
 
 test/ft/errors/%.out:
 	$(CXX) test/ft/errors/$*.cpp $(CXXFLAGS) -I include 2> /dev/null || [ $$? -ne 0 ]
 
 test/ft/%.out:
-	$(CXX) test/ft/$*.cpp $(CXXFLAGS) -fno-exceptions $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/$*.out	&& $($(MEMCHECK)) test/ft/$*.out
+	$(CXX) test/ft/$*.cpp $(CXXFLAGS) $(DISABLE_EXCEPTIONS) $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/$*.out && $($(MEMCHECK)) test/ft/$*.out
 
 test/ft/sizeof.out:
-	$(CXX) test/ft/sizeof.cpp $(CXXFLAGS) -ftemplate-depth=1024 -fno-exceptions $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/sizeof.out && $($(MEMCHECK)) test/ft/sizeof.out
+	$(CXX) test/ft/sizeof.cpp $(CXXFLAGS) -ftemplate-depth=1024 $(DISABLE_EXCEPTIONS) $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/sizeof.out && $($(MEMCHECK)) test/ft/sizeof.out
 
 test/ft/state_machine.out:
-	$(CXX) test/ft/state_machine.cpp $(CXXFLAGS) -ftemplate-depth=1024 -fno-exceptions $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/state_machine.out && $($(MEMCHECK)) test/ft/state_machine.out
+	$(CXX) test/ft/state_machine.cpp $(CXXFLAGS) -ftemplate-depth=1024 $(DISABLE_EXCEPTIONS) $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/state_machine.out && $($(MEMCHECK)) test/ft/state_machine.out
 
 test/ft/exceptions.out:
 	$(CXX) test/ft/exceptions.cpp $(CXXFLAGS) $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/exceptions.out && $($(MEMCHECK)) test/ft/exceptions.out
 
 test/ft/policies_thread_safe.out: #-fsanitize=thread
-	$(CXX) test/ft/policies_thread_safe.cpp $(CXXFLAGS) -fno-exceptions -lpthread $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/policies_thread_safe.out && $($(MEMCHECK)) test/ft/policies_thread_safe.out
+	$(CXX) test/ft/policies_thread_safe.cpp $(CXXFLAGS) $(DISABLE_EXCEPTIONS) -lpthread $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/policies_thread_safe.out && $($(MEMCHECK)) test/ft/policies_thread_safe.out
 
 test/ft/units.out:
-	$(CXX) test/ft/unit1.cpp test/ft/unit2.cpp test/ft/units.cpp $(CXXFLAGS) -fno-exceptions $($(COVERAGE)) -o test/ft/units.out
+	$(CXX) test/ft/unit1.cpp test/ft/unit2.cpp test/ft/units.cpp $(CXXFLAGS) $(DISABLE_EXCEPTIONS) $($(COVERAGE)) -o test/ft/units.out
 
 example: $(patsubst %.cpp, %.out, $(wildcard example/*.cpp))
 

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -27,7 +27,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-string-literal-operator-template"
 #pragma clang diagnostic ignored "-Wzero-length-array"
-#pragma clang diagnostic ignored "-Wexpansion-to-defined"
 #elif defined(__GNUC__)
 #define __has_builtin(...) 0
 #define __BOOST_SML_UNUSED __attribute__((unused))
@@ -924,7 +923,11 @@ struct callable
     : decltype(test_callable<aux::inherit<aux::conditional_t<__is_class(T), T, aux::none_type>, callable_fallback>>(0)) {};
 }
 #if !defined(BOOST_SML_DISABLE_EXCEPTIONS)
-#define BOOST_SML_DISABLE_EXCEPTIONS !(defined(__cpp_exceptions) || defined(__EXCEPTIONS))
+#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS))
+#define BOOST_SML_DISABLE_EXCEPTIONS true
+#else
+#define BOOST_SML_DISABLE_EXCEPTIONS false
+#endif
 #endif
 namespace back {
 template <class TSM>

--- a/include/boost/sml/aux_/type_traits.hpp
+++ b/include/boost/sml/aux_/type_traits.hpp
@@ -139,7 +139,7 @@ template <class R, class T, class... TArgs>
 struct function_traits<R (T::*)(TArgs...) const> {
   using args = type_list<TArgs...>;
 };
-#if __cplusplus > 201402L // __pph__
+#if __cplusplus > 201402L  // __pph__
 template <class R, class... TArgs>
 struct function_traits<R (*)(TArgs...) noexcept> {
   using args = type_list<TArgs...>;
@@ -156,7 +156,7 @@ template <class R, class T, class... TArgs>
 struct function_traits<R (T::*)(TArgs...) const noexcept> {
   using args = type_list<TArgs...>;
 };
-#endif // __pph__
+#endif  // __pph__
 template <class T>
 using function_traits_t = typename function_traits<T>::args;
 

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -14,9 +14,13 @@
 #include "boost/sml/back/utility.hpp"
 #include "boost/sml/concepts/callable.hpp"
 
-#if !defined(BOOST_SML_DISABLE_EXCEPTIONS)                                                  // __pph__
-#define BOOST_SML_DISABLE_EXCEPTIONS !(defined(__cpp_exceptions) || defined(__EXCEPTIONS))  // __pph__
-#endif                                                                                      // __pph__
+#if !defined(BOOST_SML_DISABLE_EXCEPTIONS)                   // __pph__
+#  if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS))  // __pph__
+#    define BOOST_SML_DISABLE_EXCEPTIONS true                // __pph__
+#  else                                                      // __pph__
+#    define BOOST_SML_DISABLE_EXCEPTIONS false               // __pph__
+#  endif                                                     // __pph__
+#endif                                                       // __pph__
 
 namespace back {
 

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -19,6 +19,7 @@ const auto idle = sml::state<class idle>;
 const auto s1 = sml::state<class s1>;
 const auto s2 = sml::state<class s2>;
 const auto s3 = sml::state<class s3>;
+const auto s4 = sml::state<class s4>;
 
 test process_event = [] {
   struct c {
@@ -52,14 +53,14 @@ test process_event_using_injected_sm = [] {
     auto operator()() const noexcept {
       using namespace sml;
       return make_transition_table(
-          *"s1"_s + event<e1> / [](bool value, auto event, auto& sm){
+          *s1 + event<e1> / [](bool value, auto event, auto& sm){
               static_expect(aux::is_same<decltype(event), e1>::value);
               if (value) {
                 sm.process_event(e2{});
               }
-            } = "s3"_s
-          ,"s1"_s + event<e2> = "s2"_s
-          ,"s3"_s + event<e2> = "s4"_s
+            } = s3
+          ,s1 + event<e2> = s2
+          ,s3 + event<e2> = s4
       );
     }
   };
@@ -68,12 +69,12 @@ test process_event_using_injected_sm = [] {
   {
     sm<c> sm{true};
     sm.process_event(e1{});
-    expect(sm.is("s4"_s));
+    expect(sm.is(s4));
   }
   {
     sm<c> sm{false};
     sm.process_event(e1{});
-    expect(sm.is("s3"_s));
+    expect(sm.is(s3));
   }
 };
 

--- a/test/ft/dispatch_table.cpp
+++ b/test/ft/dispatch_table.cpp
@@ -134,7 +134,7 @@ test dispatch_runtime_event_dynamic_id = [] {
   }
 };
 
-test dispatch_sm_with_rebind_policies  = [] {
+namespace {
   struct my_logger {
     template <class SM, class TEvent>
     void log_process_event(const TEvent&) {
@@ -158,7 +158,9 @@ test dispatch_sm_with_rebind_policies  = [] {
       printf("[%s][transition] %s -> %s\n", sml::aux::get_type_name<SM>(), src.c_str(), dst.c_str());
     }
   };
+}
 
+test dispatch_sm_with_rebind_policies = [] {
   struct c {
     auto operator()() noexcept {
       using namespace sml;

--- a/tools/pph.sh
+++ b/tools/pph.sh
@@ -29,7 +29,6 @@ pph() {
   echo "#pragma clang diagnostic push"
   echo "#pragma clang diagnostic ignored \"-Wgnu-string-literal-operator-template\""
   echo "#pragma clang diagnostic ignored \"-Wzero-length-array\""
-  echo "#pragma clang diagnostic ignored \"-Wexpansion-to-defined\""
   echo "#elif defined(__GNUC__)"
   echo "#define __has_builtin(...) 0"
   echo "#define __BOOST_SML_UNUSED __attribute__((unused))"
@@ -63,7 +62,7 @@ pph() {
     #include "boost/sml/transition_table.hpp"' > tmp.hpp
   cpp -C -P -nostdinc -I. tmp.hpp 2>/dev/null | \
     sed "s/\/\/\/\///" | \
-    sed "s/[ $]*#define/##define/g" | \
+    sed "s/[ \t$]*#[ \t]*define/##define/g" | \
     cpp -P -I. -fpreprocessed - 2>/dev/null | \
     sed "s/clang-format\(.*\)/\/\/ clang-format\1/g" | \
     sed "s/^##define/#define/g"


### PR DESCRIPTION
Fixed several warnings concerning *GCC*, *Clang* and *MSVC* that were treated as errors by the `Makefile`.

Note, however, that *MSVC* probably still cannot compile the code due to some other errors. (See continuous-integration results of *Appveyor*.)

Compiling the *SDL2* example with *GCC* still fails, because I was unable to fix (or even locate) the following warning which is treated as an error:

```
g++-6 example/sdl2.cpp -std=c++1y -Wall -Wextra -Werror -pedantic -pedantic-errors -I include -I . -o example/sdl2.out &&  example/sdl2.out
In file included from example/sdl2.cpp:8:0:
include/boost/sml.hpp: In instantiation of ‘struct boost::sml::v1_1_0::back::sm_impl<boost::sml::v1_1_0::back::sm_policy<sdl2> >::mappings’:
include/boost/sml.hpp:911:63:   required by substitution of ‘template<class T, class TMappings> using get_event_mapping_t = decltype (get_event_mapping_impl<T>((TMappings*)(0))) [with T = boost::sml::v1_1_0::back::event_type<boost::sml::v1_1_0::back::anonymous>::generic_t; TMappings = boost::sml::v1_1_0::back::sm_impl<boost::sml::v1_1_0::back::sm_policy<sdl2> >::mappings]’
include/boost/sml.hpp:1023:12:   required from ‘bool boost::sml::v1_1_0::back::sm_impl< <template-parameter-1-1> >::process_internal_events(const TEvent&, TDeps&, TSubs&) [with TEvent = boost::sml::v1_1_0::back::anonymous; TDeps = boost::sml::v1_1_0::aux::pool<>; TSubs = boost::sml::v1_1_0::aux::pool<boost::sml::v1_1_0::back::sm_impl<boost::sml::v1_1_0::back::sm_policy<sdl2> > >; typename boost::sml::v1_1_0::aux::enable_if<(boost::sml::v1_1_0::aux::integral_constant<bool, __is_base_of(typename boost::sml::v1_1_0::back::event_type<TEvent>::generic_t, typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::aux::inherit, typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::aux::unique_t, typename boost::sml::v1_1_0::aux::join<typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::back::get_sub_internal_events, decltype((declval<typename TSM::sm>)().operator()())>::type, typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::back::get_events, decltype((declval<typename TSM::sm>)().operator()())>::type>::type>::type>::type)>::value && (! boost::sml::v1_1_0::aux::integral_constant<bool, __is_base_of(typename boost::sml::v1_1_0::back::event_type<TEvent>::mapped_t, typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::aux::inherit, typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::aux::unique_t, typename boost::sml::v1_1_0::aux::join<typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::back::get_sub_internal_events, decltype((declval<typename TSM::sm>)().operator()())>::type, typename boost::sml::v1_1_0::aux::apply<boost::sml::v1_1_0::back::get_events, decltype((declval<typename TSM::sm>)().operator()())>::type>::type>::type>::type)>::value)), int>::type <anonymous> = 0; TSM = boost::sml::v1_1_0::back::sm_policy<sdl2>]’
include/boost/sml.hpp:1006:5:   required from ‘void boost::sml::v1_1_0::back::sm_impl< <template-parameter-1-1> >::start(TDeps&, TSubs&) [with TDeps = boost::sml::v1_1_0::aux::pool<>; TSubs = boost::sml::v1_1_0::aux::pool<boost::sml::v1_1_0::back::sm_impl<boost::sml::v1_1_0::back::sm_policy<sdl2> > >; TSM = boost::sml::v1_1_0::back::sm_policy<sdl2>]’
include/boost/sml.hpp:1245:5:   required from ‘boost::sml::v1_1_0::back::sm< <template-parameter-1-1> >::sm(TDeps&& ...) [with TDeps = {}; typename boost::sml::v1_1_0::aux::enable_if<boost::sml::v1_1_0::aux::is_unique<boost::sml::v1_1_0::aux::none_type, TDeps ...>::value, int>::type <anonymous> = 0; TSM = boost::sml::v1_1_0::back::sm_policy<sdl2>]’
include/boost/sml.hpp:1648:8:   required from here
include/boost/sml.hpp:965:10: error: ‘boost::sml::v1_1_0::back::sm_impl<boost::sml::v1_1_0::back::sm_policy<sdl2> >::mappings’ has a base ‘boost::sml::v1_1_0::aux::inherit<boost::sml::v1_1_0::back::event_mappings<sdl_event_impl<(SDL_EventType)1u>, boost::sml::v1_1_0::aux::inherit<boost::sml::v1_1_0::back::state_mappings<boost::sml::v1_1_0::aux::string<char, 'w', 'a', 'i', 't', 'i', 'n', 'g', '_', 'f', 'o', 'r', '_', 'q', 'u', 'i', 't'>, boost::sml::v1_1_0::aux::type_list<boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::back::terminate_state>, boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::aux::string<char, 'w', 'a', 'i', 't', 'i', 'n', 'g', '_', 'f', 'o', 'r', '_', 'q', 'u', 'i', 't'>(boost::sml::v1_1_0::front::initial_state)>, boost::sml::v1_1_0::front::transition_ea<boost::sml::v1_1_0::front::event<sdl_event_impl<(SDL_EventType)1u> >, boost::sml::v1_1_0::aux::zero_wrapper<sdl2::operator()() const::<lambda()>, void> > > > > > > >, boost::sml::v1_1_0::back::event_mappings<sdl_event_impl<(SDL_EventType)3u>, boost::sml::v1_1_0::aux::inherit<boost::sml::v1_1_0::back::state_mappings<boost::sml::v1_1_0::aux::string<char, 'k', 'e', 'y', '_', 'p', 'r', 'e', 's', 's', 'e', 'd'>, boost::sml::v1_1_0::aux::type_list<boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::back::terminate_state>, boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::aux::string<char, 'k', 'e', 'y', '_', 'p', 'r', 'e', 's', 's', 'e', 'd'> >, boost::sml::v1_1_0::front::transition_ea<boost::sml::v1_1_0::front::event<sdl_event_impl<(SDL_EventType)3u> >, boost::sml::v1_1_0::aux::zero_wrapper<sdl2::operator()() const::<lambda()>, void> > > > > > > >, boost::sml::v1_1_0::back::event_mappings<sdl_event_impl<(SDL_EventType)2u>, boost::sml::v1_1_0::aux::inherit<boost::sml::v1_1_0::back::state_mappings<boost::sml::v1_1_0::aux::string<char, 'w', 'a', 'i', 't', '_', 'f', 'o', 'r', '_', 'u', 's', 'e', 'r', '_', 'i', 'n', 'p', 'u', 't'>, boost::sml::v1_1_0::aux::type_list<boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::aux::string<char, 'k', 'e', 'y', '_', 'p', 'r', 'e', 's', 's', 'e', 'd'> >, boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::aux::string<char, 'w', 'a', 'i', 't', '_', 'f', 'o', 'r', '_', 'u', 's', 'e', 'r', '_', 'i', 'n', 'p', 'u', 't'> >, boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::event<sdl_event_impl<(SDL_EventType)2u> >, boost::sml::v1_1_0::aux::zero_wrapper<<lambda(auto:3)> [with auto:3 = <anonymous enum>]::<lambda(auto:4)>, void>, boost::sml::v1_1_0::aux::zero_wrapper<sdl2::operator()() const::<lambda()>, void> > > > > > > >, boost::sml::v1_1_0::back::event_mappings<boost::sml::v1_1_0::back::anonymous, boost::sml::v1_1_0::aux::inherit<boost::sml::v1_1_0::back::state_mappings<boost::sml::v1_1_0::aux::string<char, 'i', 'd', 'l', 'e'>, boost::sml::v1_1_0::aux::type_list<boost::sml::v1_1_0::front::transition<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::aux::string<char, 'w', 'a', 'i', 't', '_', 'f', 'o', 'r', '_', 'u', 's', 'e', 'r', '_', 'i', 'n', 'p', 'u', 't'> >, boost::sml::v1_1_0::front::transition_sa<boost::sml::v1_1_0::front::state<boost::sml::v1_1_0::aux::string<char, 'i', 'd', 'l', 'e'>(boost::sml::v1_1_0::front::initial_state)>, boost::sml::v1_1_0::aux::zero_wrapper<sdl2::operator()() const::<lambda()>, void> > > > > > > >’ whose type uses the anonymous namespace [-Werror=subobject-linkage]
   struct mappings : mappings_t<transitions_t> {};
          ^~~~~~~~
cc1plus: all warnings being treated as errors
```
