### PR TITLE
[C++17] Additional feature-test to prevent compiler-errors.

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -170,7 +170,7 @@ template <class R, class T, class... TArgs>
 struct function_traits<R (T::*)(TArgs...) const> {
   using args = type_list<TArgs...>;
 };
-#if __cplusplus > 201402L
+#if __cplusplus > 201402L && __cpp_noexcept_function_type >= 201510
 template <class R, class... TArgs>
 struct function_traits<R (*)(TArgs...) noexcept> {
   using args = type_list<TArgs...>;

--- a/include/boost/sml/aux_/type_traits.hpp
+++ b/include/boost/sml/aux_/type_traits.hpp
@@ -139,7 +139,7 @@ template <class R, class T, class... TArgs>
 struct function_traits<R (T::*)(TArgs...) const> {
   using args = type_list<TArgs...>;
 };
-#if __cplusplus > 201402L  // __pph__
+#if __cplusplus > 201402L && __cpp_noexcept_function_type >= 201510  // __pph__
 template <class R, class... TArgs>
 struct function_traits<R (*)(TArgs...) noexcept> {
   using args = type_list<TArgs...>;


### PR DESCRIPTION
Older compiles might partially support C++17 but not support that `noexcept` became part of the type-system.
To prevent compiler-errors with these compilers an additional feature-test for that feature guards the additional type_traits which use that feature.

This fixes #126 .