### PR TITLE
Fix #110. Transitions with event<_> no longer ignore guards and actions.

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -907,8 +907,14 @@ template <class>
 transitions<aux::true_type> get_event_mapping_impl(...);
 template <class T, class TMappings>
 TMappings get_event_mapping_impl(event_mappings<T, TMappings> *);
+template <class T, class... T1Mappings, class... T2Mappings>
+unique_mappings_t<T1Mappings..., T2Mappings...> get_event_mapping_impl(event_mappings<T, aux::inherit<T1Mappings...>> *,
+                                                                       event_mappings<_, aux::inherit<T2Mappings...>> *);
 template <class T, class TMappings>
-using get_event_mapping_t = decltype(get_event_mapping_impl<T>((TMappings *)0));
+using get_event_mapping_t = typename aux::conditional<
+    aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<_>((TMappings *)0))>::value,
+    decltype(get_event_mapping_impl<T>((TMappings *)0)),
+    decltype(get_event_mapping_impl<T>((TMappings *)0, (TMappings *)0))>::type;
 }
 namespace concepts {
 struct callable_fallback {

--- a/include/boost/sml/back/mappings.hpp
+++ b/include/boost/sml/back/mappings.hpp
@@ -141,8 +141,15 @@ transitions<aux::true_type> get_event_mapping_impl(...);
 template <class T, class TMappings>
 TMappings get_event_mapping_impl(event_mappings<T, TMappings> *);
 
+template <class T, class... T1Mappings, class... T2Mappings>
+unique_mappings_t<T1Mappings..., T2Mappings...> get_event_mapping_impl(event_mappings<T, aux::inherit<T1Mappings...>> *,
+                                                                       event_mappings<_, aux::inherit<T2Mappings...>> *);
+
 template <class T, class TMappings>
-using get_event_mapping_t = decltype(get_event_mapping_impl<T>((TMappings *)0));
+using get_event_mapping_t = typename aux::conditional<
+    aux::is_same<transitions<aux::true_type>, decltype(get_event_mapping_impl<_>((TMappings *)0))>::value,
+    decltype(get_event_mapping_impl<T>((TMappings *)0)),
+    decltype(get_event_mapping_impl<T>((TMappings *)0, (TMappings *)0))>::type;
 
 }  // back
 


### PR DESCRIPTION
Now, it is possible to create a transition-table that has multiple transitions that match any event (via `event<_>`) but still can use guards and actions to distinguish between them.

**Note 1:** However, the events that should be matched by such transitions still must be used (verbatim) in some other (possibly unreachable) transition of the transition-table or they would be considered as *'unexpected'* events and not being considered by such *"catch-all"* transitions. (See issue #88.)

**Note 2:** If two transitions exist for a source-state that might match event `e1`, one directly using `event<e1>`, the other using `event<_>`, the translation with the more-specific form is always a better match, regardless of the order in which they appear in the transition-table.

For example, the following will always trigger `action1`.
```cpp
...
struct TransitionTable
{
    auto operator() () const noexcept
    {
        return make_transition_table(
             *"s1"_s + event<_> [is_event_e1] / action2
            , "s1"_s + event<e1> / action1
        );
    }
};
...
sm.process_event(e1{});
...
```
This would also be true if the first transition would not have a guard. (This is no new behavior and always worked like that.)

---
This fixes #110.