### PR TITLE
example/SDL2: Remove warning (which is interpreted as error).

### DIFF
--- a/example/sdl2.cpp
+++ b/example/sdl2.cpp
@@ -50,7 +50,11 @@ struct sdl_event_impl {
 template <SDL_EventType Id>
 decltype(sml::event<sdl_event_impl<Id>>) sdl_event{};
 
-auto is_key = [](auto key) { return [=](auto event) { return event.data.key.keysym.sym == key; }; };
+struct IsKey {
+  auto operator()(int key) {
+    return [=](auto event) { return event.data.key.keysym.sym == key; };
+  }
+} is_key;
 
 struct sdl2 {
   auto operator()() const noexcept {


### PR DESCRIPTION
Compilation of `example/sdl2.cpp` fails due to warnings being interpreted as errors.

This pull-request fixes that particular warning.
The rational behind it can be found in #135.

Fixes #135.