### PR TITLE
Fix operator precedence of get_arg for actions handling exception<>

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -470,7 +470,7 @@ struct on_exit : internal_event, entry_exit {
   explicit on_exit(const TEvent &event = {}) : event_(event) {}
   const TEvent &event_;
 };
-template <class TException>
+template <class T, class TException = T>
 struct exception : internal_event {
   using type = TException;
   explicit exception(const TException &exception = {}) : exception_(exception) {}
@@ -1394,7 +1394,7 @@ decltype(auto) get_arg(const aux::type<const TEvent &> &, const back::on_exit<T,
   return event.event_;
 }
 template <class T, class TEvent, class TSM, class TDeps>
-decltype(auto) get_arg(const aux::type<T> &, const back::exception<TEvent> &event, TSM &, TDeps &) {
+decltype(auto) get_arg(const aux::type<const TEvent &> &, const back::exception<T, TEvent> &event, TSM &, TDeps &) {
   return event.exception_;
 }
 template <class, class, class>

--- a/include/boost/sml/back/internals.hpp
+++ b/include/boost/sml/back/internals.hpp
@@ -40,7 +40,7 @@ struct on_exit : internal_event, entry_exit {
   const TEvent& event_;
 };
 
-template <class TException>
+template <class T, class TException = T>
 struct exception : internal_event {
   using type = TException;
   explicit exception(const TException& exception = {}) : exception_(exception) {}

--- a/include/boost/sml/front/operators.hpp
+++ b/include/boost/sml/front/operators.hpp
@@ -79,7 +79,7 @@ decltype(auto) get_arg(const aux::type<const TEvent &> &, const back::on_exit<T,
   return event.event_;
 }
 template <class T, class TEvent, class TSM, class TDeps>
-decltype(auto) get_arg(const aux::type<T> &, const back::exception<TEvent> &event, TSM &, TDeps &) {
+decltype(auto) get_arg(const aux::type<const TEvent &> &, const back::exception<T, TEvent> &event, TSM &, TDeps &) {
   return event.exception_;
 }
 

--- a/test/ft/exceptions.cpp
+++ b/test/ft/exceptions.cpp
@@ -239,14 +239,14 @@ test exception_and_context = [] {
       // clang-format off
         return make_transition_table(
            *idle + event<e1> / [] { throw exception1{}; } = s1
-          , s1 + exception<exception1> / [](const context &,const auto &){} = X
+          , s1 + exception<exception1> / [](context &,const auto &){} = X
         );
       // clang-format on
     }
   };
 
   context ctx{};
-  sml::sm<c> sm{&ctx};
+  sml::sm<c> sm{ctx};
   sm.process_event(e1{});  // throws exception1
   expect(sm.is(sml::X));
 };


### PR DESCRIPTION
It is not possible to write an action that accepts both an exception and an object injected into the state machine constructor e.g.

This works

    "state1"_s + exception<std::exception> / [](std::exception const & e){std::cout << e.what << std::endl;} = "state2"_s

This fails

    "state1"_s + exception<std::exception> / [](my_logger & log,std::exception const & e){log(e.what());} = "state2"_s

This is caused by the specialization of get_arg for back::exception always taking precedence over the default implementation. This pull request removes the  "class T" template argument fixing the operator precedence.