### PR TITLE
:books: Correct on-the-fly event creation documentation

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -29,7 +29,7 @@ If you happen to have a Clang/GCC compiler, you can create an Event on the fly.
 
 ```cpp
 using namespace sml;
-auto event  = "event"_t;
+auto event  = "event"_e;
 ```
 
 However, such event will not store any data.


### PR DESCRIPTION
Problem:
- The documentation for creating an event on the fly contains a typo,
  which causes confusion on the part of new users.

Solution:
- Correct the typo.