### PR TITLE
:new: :art: Simplify dependency injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,6 @@ matrix:
 # Build
 #
   - os: linux
-    dist: precise
-    env: CXX=clang++-3.6 MEMCHECK=VALGRIND
-    addons: { apt: { packages: ["clang-3.6", "libstdc++-5-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.6"] } }
-    dist: precise
-
-  - os: linux
     env: CXX=clang++-3.7 MEMCHECK=VALGRIND
     addons: { apt: { packages: ["clang-3.7", "libstdc++-5-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.7"] } }
 

--- a/include/boost/sml/aux_/type_traits.hpp
+++ b/include/boost/sml/aux_/type_traits.hpp
@@ -103,19 +103,17 @@ using is_constructible = decltype(test_is_constructible<T, TArgs...>(0));
 #endif  // __pph__
 
 template <class T>
-struct remove_reference {
-  using type = T;
-};
+struct is_const : false_type {};
 template <class T>
-struct remove_reference<T &> {
-  using type = T;
+struct is_const<const T> : true_type {};
+
+template <class T, class U>
+struct is_empty_base : T {
+  U _;
 };
+
 template <class T>
-struct remove_reference<T &&> {
-  using type = T;
-};
-template <class T>
-using remove_reference_t = typename remove_reference<T>::type;
+struct is_empty : aux::integral_constant<bool, sizeof(is_empty_base<T, none_type>) == sizeof(none_type)> {};
 
 template <class>
 struct function_traits;
@@ -168,16 +166,19 @@ template <class T>
 using remove_const_t = typename remove_const<T>::type;
 
 template <class T>
-struct is_const : false_type {};
+struct remove_reference {
+  using type = T;
+};
 template <class T>
-struct is_const<const T> : true_type {};
-
+struct remove_reference<T &> {
+  using type = T;
+};
 template <class T>
-struct is_reference : false_type {};
+struct remove_reference<T &&> {
+  using type = T;
+};
 template <class T>
-struct is_reference<T &> : true_type {};
-template <class T>
-struct is_reference<T &&> : true_type {};
+using remove_reference_t = typename remove_reference<T>::type;
 
 }  // aux
 

--- a/include/boost/sml/back/policies.hpp
+++ b/include/boost/sml/back/policies.hpp
@@ -34,6 +34,8 @@ TPolicy get_policy(aux::pair<T, TPolicy> *);
 
 template <class SM, class... TPolicies>
 struct sm_policy {
+  static_assert(aux::is_same<aux::remove_reference_t<SM>, SM>::value, "SM type can't have qualifiers");
+
   using sm = SM;
   using thread_safety_policy =
       decltype(get_policy<no_policy, policies::thread_safety_policy__>((aux::inherit<TPolicies...> *)0));

--- a/include/boost/sml/back/utility.hpp
+++ b/include/boost/sml/back/utility.hpp
@@ -105,6 +105,10 @@ template <class... Ts>
 using get_sm_t = aux::type_list<typename Ts::sm...>;
 
 template <class... Ts>
+using get_non_empty_t =
+    aux::join_t<typename aux::conditional<aux::is_empty<Ts>::value, aux::type_list<>, aux::type_list<Ts>>::type...>;
+
+template <class... Ts>
 using merge_deps = aux::join_t<typename Ts::deps...>;
 
 template <class>

--- a/include/boost/sml/front/state.hpp
+++ b/include/boost/sml/front/state.hpp
@@ -102,7 +102,7 @@ struct state<TState(history_state)> : state_impl<state<TState(history_state)>> {
 };
 
 #if defined(_MSC_VER)  // __pph__
-template <class T, class T__ = decltype(aux::declval<T>()), class = void>
+template <class T, class T__ = aux::remove_reference_t<decltype(aux::declval<T>())>, class = void>
 struct state_sm {
   using type = state<T>;
 };

--- a/include/boost/sml/state_machine.hpp
+++ b/include/boost/sml/state_machine.hpp
@@ -26,7 +26,7 @@ using defer_queue = back::policies::defer_queue<T, front::actions::defer_event>;
 /// state machine
 
 #if defined(_MSC_VER)  // __pph__
-template <class T, class... TPolicies, class T__ = decltype(aux::declval<T>())>
+template <class T, class... TPolicies, class T__ = aux::remove_reference_t<decltype(aux::declval<T>())>>
 using sm = back::sm<back::sm_policy<T__, TPolicies...>>;
 #else   // __pph__
 template <class T, class... TPolicies>

--- a/test/ft/actions_defer.cpp
+++ b/test/ft/actions_defer.cpp
@@ -103,8 +103,8 @@ test defer_and_transitions = [] {
     std::vector<int> entries;
   };
 
-  c c_;
-  sml::sm<c, sml::defer_queue<std::queue>> sm{c_};
+  sml::sm<c, sml::defer_queue<std::queue>> sm;
+  const c& c_ = sm;
   sm.process_event(event1());
   sm.process_event(event1());
   sm.process_event(event2());
@@ -120,6 +120,8 @@ test defer_and_transitions = [] {
 
 test defer_and_anonymous = [] {
   struct c {
+    c() {}
+
     auto operator()() {
       using namespace sml;
       // clang-format off
@@ -141,8 +143,8 @@ test defer_and_anonymous = [] {
     std::vector<int> entries;
   };
 
-  c c_;
-  sml::sm<c, sml::defer_queue<std::queue>> sm{c_};
+  sml::sm<c, sml::defer_queue<std::queue>> sm{c{}};
+  const c& c_ = sm;
   sm.process_event(event1());
   sm.process_event(event2());
 

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -36,8 +36,8 @@ test process_event = [] {
     int a_called = 0;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{};
+  c& c_ = sm;
   expect(sm.is(idle));
   sm.process_event(e1{});
   expect(sm.is(s1));
@@ -76,8 +76,8 @@ test process_event_from_substate = [] {
     int a_called = 0;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm;
+  const c& c_ = sm;
   expect(sm.is(idle));
   expect(sm.is<decltype(sml::state<sub>)>(s1));
 

--- a/test/ft/composite.cpp
+++ b/test/ft/composite.cpp
@@ -74,9 +74,10 @@ test composite = [] {
     bool a_on_entry_sub_sm = false;
   };
 
-  c c_;
-  sub sub_;
-  sml::sm<c> sm{c_, sub_, 87.0, 42};
+  sml::sm<c> sm{87.0, 42};
+
+  c& c_ = sm;
+  sub& sub_ = sm;
 
   expect(sm.is(idle));
   sm.process_event(e1());
@@ -206,7 +207,10 @@ test composite_custom_ctor = [] {
   };
 
   constexpr auto i = 2;
-  auto test = [=](auto&& sm) {
+
+  {
+    in_sub = 0;
+    sml::sm<c> sm{sub{i}};
     expect(sm.is(idle));
     sm.process_event(e1());
 
@@ -221,27 +225,44 @@ test composite_custom_ctor = [] {
     sm.process_event(e5());
     expect(2 * i == in_sub);
     expect(sm.is(s2));
-  };
-
-  {
-    in_sub = 0;
-    sub sub_{i};
-    sml::sm<c> sm{sub_};
-    test(static_cast<decltype(sm)&&>(sm));
   }
 
   {
     in_sub = 0;
-    sub sub_{i};
-    sml::sm<c> sm{sub_};
-    test(static_cast<decltype(sm)&&>(sm));
+    sml::sm<c> sm{sub{i}};
+    expect(sm.is(idle));
+    sm.process_event(e1());
+
+    sm.process_event(e2());
+    expect(0 == in_sub);
+
+    sm.process_event(e3());
+    expect(1 * i == in_sub);
+
+    sm.process_event(e4());
+    expect(2 * i == in_sub);
+    sm.process_event(e5());
+    expect(2 * i == in_sub);
+    expect(sm.is(s2));
   }
 
   {
     in_sub = 0;
-    sub sub_{i};
-    sml::sm<c> sm{sub_};
-    test(static_cast<decltype(sm)&&>(sm));
+    sml::sm<c> sm{sub{i}};
+    expect(sm.is(idle));
+    sm.process_event(e1());
+
+    sm.process_event(e2());
+    expect(0 == in_sub);
+
+    sm.process_event(e3());
+    expect(1 * i == in_sub);
+
+    sm.process_event(e4());
+    expect(2 * i == in_sub);
+    sm.process_event(e5());
+    expect(2 * i == in_sub);
+    expect(sm.is(s2));
   }
 };
 
@@ -316,9 +337,9 @@ test composite_entry_exit_initial = [] {
     int exit_calls = 0;
   };
 
-  sub sub_;
-  c c_;
-  sml::sm<c> sm{c_, sub_};
+  sml::sm<c> sm;
+  const sub& sub_ = sm;
+  const c& c_ = sm;
   expect(1 == c_.entry_calls);
   expect(0 == c_.exit_calls);
   expect(1 == sub_.entry_calls);

--- a/test/ft/history.cpp
+++ b/test/ft/history.cpp
@@ -55,9 +55,7 @@ test history = [] {
 
   using namespace sml;
 
-  c c_;
-  sub sub_;
-  sml::sm<c> sm{c_, sub_};
+  sml::sm<c> sm{};
 
   expect(sm.is(idle));
   sm.process_event(e1());

--- a/test/ft/orthogonal_regions.cpp
+++ b/test/ft/orthogonal_regions.cpp
@@ -100,8 +100,8 @@ test orthogonal_regions_initial_entry = [] {
     int entry_2 = 0;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{c{}};
+  const c& c_ = sm;
   expect(1 == c_.entry_1);
   expect(1 == c_.entry_2);
 };
@@ -168,8 +168,8 @@ test orthogonal_regions_entry_exit = [] {
     int a_exit_action = 0;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{};
+  c& c_ = sm;
   sm.process_event(e1{});
   expect(c_.a_entry_action == 1);
   expect(c_.a_exit_action == 0);

--- a/test/ft/policies_testing.cpp
+++ b/test/ft/policies_testing.cpp
@@ -52,8 +52,7 @@ test sm_testing = [] {
 
   {
     data fake_data;
-    const data &c_fake_data = fake_data;
-    sml::sm<c, sml::testing> sm{c_fake_data, fake_data, true};
+    sml::sm<c, sml::testing> sm{fake_data, true};
     expect(sm.is(idle));
 
     sm.process_event(e1{});
@@ -68,8 +67,7 @@ test sm_testing = [] {
 
   {
     data fake_data;
-    const data &c_fake_data = fake_data;
-    sml::sm<c, sml::testing> sm{fake_data, c_fake_data, true};
+    sml::sm<c, sml::testing> sm{fake_data, true};
     expect(sm.is(idle));
 
     sm.set_current_states(s2);
@@ -81,8 +79,7 @@ test sm_testing = [] {
 
   {
     data fake_data;
-    const data &c_fake_data = fake_data;
-    sml::sm<c, sml::testing> sm{c_fake_data, fake_data, true};
+    sml::sm<c, sml::testing> sm{fake_data, true};
     expect(sm.is(idle));
 
     sm.set_current_states(s2);
@@ -94,8 +91,7 @@ test sm_testing = [] {
 
   {
     data fake_data;
-    const data &c_fake_data = fake_data;
-    sml::sm<c, sml::testing> sm{fake_data, c_fake_data, true};
+    sml::sm<c, sml::testing> sm{fake_data, true};
     expect(sm.is(idle));
 
     sm.set_current_states(s1);

--- a/test/ft/policies_thread_safe.cpp
+++ b/test/ft/policies_thread_safe.cpp
@@ -36,8 +36,8 @@ test process_the_same_event = [] {
     int action2_calls = 0;
   };
 
-  actions_guards ag;
-  sml::sm<actions_guards, sml::thread_safe<std::mutex>> sm{ag};
+  sml::sm<actions_guards, sml::thread_safe<std::mutex>> sm{};
+  const actions_guards& ag = sm;
   std::thread t1{[&] { sm.process_event(e1{}); }};
   std::thread t2{[&] { sm.process_event(e2{}); }};
   t1.join();

--- a/test/ft/state_machine.cpp
+++ b/test/ft/state_machine.cpp
@@ -54,8 +54,7 @@ test sm_ctor = [] {
     }
   };
 
-  c c_{42};
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{c{42}};
   (void)sm;
 
 };

--- a/test/ft/states.cpp
+++ b/test/ft/states.cpp
@@ -98,8 +98,8 @@ test states_entry_exit_actions = [] {
     int a_exit_action = 0;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{};
+  c& c_ = sm;
   expect(!c_.a_entry_action);
   expect(sm.is(idle));
   sm.process_event(e1{});
@@ -165,8 +165,8 @@ test states_generic_entry_actions_with_events = [] {
     std::vector<std::type_index> entries;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm;
+  c& c_ = sm;
   expect(1 == c_.entries.size());
   expect(std::type_index(typeid(sml::anonymous)) == c_.entries[0]);
   c_.entries.clear();
@@ -208,8 +208,8 @@ test states_initial_entry_actions_with_events = [] {
     std::vector<std::type_index> entries;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{};
+  c& c_ = sm;
   expect(3 == c_.entries.size());
   expect(std::vector<std::type_index>{std::type_index(typeid(sml::initial)), std::type_index(typeid(sml::anonymous)),
                                       std::type_index(typeid(sml::anonymous))} == c_.entries);

--- a/test/ft/transitions.cpp
+++ b/test/ft/transitions.cpp
@@ -78,13 +78,13 @@ test anonymous_transition = [] {
       );
       // clang-format on
     }
+
     bool a_called = false;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{};
   expect(sm.is(s1));
-  expect(c_.a_called);
+  expect(static_cast<const c&>(sm).a_called);
 };
 
 test self_transition = [] {
@@ -140,8 +140,8 @@ test transition_with_action_with_event = [] {
     bool called = false;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm;
+  const c& c_ = sm;
   expect(sm.is(idle));
   sm.process_event(e1{});
   expect(c_.called);
@@ -162,8 +162,8 @@ test transition_with_action_with_parameter = [] {
     bool called = false;
   };
 
-  c c_;
-  sml::sm<c> sm{c_, 42};
+  sml::sm<c> sm{42};
+  const c& c_ = sm;
   sm.process_event(e1{});
   expect(c_.called);
   expect(sm.is(s1));
@@ -196,8 +196,8 @@ test transition_with_action_and_guad_with_parameter = [] {
     bool g_called = false;
   };
 
-  c c_;
-  sml::sm<c> sm{c_, 87.0, 42};
+  sml::sm<c> sm{87.0, 42};
+  const c& c_ = sm;
   sm.process_event(e1{});
   expect(c_.g_called);
   expect(c_.a_called);
@@ -233,9 +233,9 @@ test transition_with_action_and_guad_with_parameters_and_event = [] {
     bool g_called = false;
   };
 
-  c c_;
   auto f = 12.f;
-  sml::sm<c> sm{c_, 42, 87.0, f};
+  sml::sm<c> sm{42, 87.0, f};
+  const c& c_ = sm;
   sm.process_event(e1{});
   expect(c_.g_called);
   expect(c_.a_called);
@@ -465,8 +465,8 @@ test initial_entry = [] {
     int entry_calls = 0;
   };
 
-  c c_;
-  sml::sm<c> sm{c_};
+  sml::sm<c> sm{};
+  const c& c_ = sm;
   expect(1 == c_.entry_calls);
 };
 

--- a/test/ft/unexpected_events.cpp
+++ b/test/ft/unexpected_events.cpp
@@ -135,8 +135,8 @@ test unexpected_any_event = [] {
   };
 
   int i = 0;
-  c c_;
-  sml::sm<c> sm{c_, i};
+  sml::sm<c> sm{i};
+  c& c_ = sm;
   using namespace sml;
   sm.process_event(e1{});
   expect(sm.is(is_handled));

--- a/test/ut/type_traits.cpp
+++ b/test/ut/type_traits.cpp
@@ -57,4 +57,13 @@ test function_traits_parameters_type_const_methods = [] {
   static_expect(is_same<type_list<int, const double&>, typename function_traits<decltype(&c2::f3)>::args>::value);
 };
 
+test is_empty_type = [] {
+  struct empty {};
+  struct non_empty {
+    int _;
+  };
+  static_expect(is_empty<empty>::value);
+  static_expect(!is_empty<non_empty>::value);
+};
+
 }  // aux

--- a/test/ut/utility.cpp
+++ b/test/ut/utility.cpp
@@ -73,6 +73,7 @@ test tuple_same_types = [] {
 test pool_empty = [] {
   pool<> p;
   static_expect(0 == size<decltype(p)>::value);
+  (void)p;
 };
 
 test pool_basic = [] {


### PR DESCRIPTION
Problem:
- DI implementation is overcomplicated in the pool.

Solution:
- Simplify it by doing the work in try_get instead.