### PR TITLE
:art: [back-end][policies] Refactor thread safe policy

### DIFF
--- a/include/boost/sml/back/policies.hpp
+++ b/include/boost/sml/back/policies.hpp
@@ -17,7 +17,7 @@
 
 namespace back {
 
-struct no_policy {
+struct no_policy : policies::thread_safety_policy__ {
   using type = no_policy;
   template <class>
   using rebind = no_policy;

--- a/include/boost/sml/back/policies/thread_safety.hpp
+++ b/include/boost/sml/back/policies/thread_safety.hpp
@@ -12,11 +12,25 @@
 namespace back {
 namespace policies {
 
-struct thread_safety_policy__ {};
+struct thread_safety_policy__ {
+  auto create_lock() { return *this; }
+  __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
+};
 
-template <class T>
-struct thread_safe : aux::pair<thread_safety_policy__, thread_safe<T>> {
-  using type = T;
+template <class TLock>
+struct thread_safe : aux::pair<thread_safety_policy__, thread_safe<TLock>> {
+  using type = thread_safe;
+
+  auto create_lock() {
+    struct lock_guard {
+      explicit lock_guard(TLock &lock) : lock_{lock} { lock_.lock(); }
+      ~lock_guard() { lock_.unlock(); }
+      TLock &lock_;
+    };
+    return lock_guard{lock};
+  }
+
+  TLock lock;
 };
 
 }  // policies


### PR DESCRIPTION
Problem:
- Policies are coupled to the SM.

Solution:
- Extract policies implementation into the policy itself.