### PR TITLE
:bug: Process all anonymous transitions

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1289,7 +1289,8 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   template <class TDeps, class TSubs>
   void start(TDeps &deps, TSubs &subs) {
     process_internal_events(on_entry<_, initial>{}, deps, subs);
-    process_internal_events(anonymous{}, deps, subs);
+    while (process_internal_events(anonymous{}, deps, subs))
+      ;
     process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{});
   }
   template <class TEvent, class TDeps, class TSubs, class... Ts,

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -112,7 +112,8 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   template <class TDeps, class TSubs>
   void start(TDeps &deps, TSubs &subs) {
     process_internal_events(on_entry<_, initial>{}, deps, subs);
-    process_internal_events(anonymous{}, deps, subs);
+    while (process_internal_events(anonymous{}, deps, subs))
+      ;
     process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{});
   }
 

--- a/test/ft/transitions.cpp
+++ b/test/ft/transitions.cpp
@@ -87,6 +87,27 @@ test anonymous_transition = [] {
   expect(static_cast<const c&>(sm).a_called);
 };
 
+test anonymous_transition_recursive = [] {
+  struct c {
+    auto operator()() noexcept {
+      auto is_true = [] { return true; };
+      auto is_false = [] { return false; };
+
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+        (*idle)[is_true] = s1,
+         idle [is_false] = s2,
+         s1= X
+      // clang-format on
+      );
+    }
+  };
+
+  sml::sm<c> sm{};
+  expect(sm.is(sml::X));
+};
+
 test self_transition = [] {
   enum class calls { s1_entry, s1_exit, s1_action };
 


### PR DESCRIPTION
Problem:
- Only first anonymous transition is handled.

Solution:
- Process anonymous transitions in the looop.