### PR TITLE
:bug: Fix #169 - Plantuml example - too much output when compiling wi…

### DIFF
--- a/example/plant_uml.cpp
+++ b/example/plant_uml.cpp
@@ -13,7 +13,6 @@
 
 namespace sml = boost::sml;
 
-namespace {
 struct e1 {};
 struct e2 {};
 struct e3 {};
@@ -64,15 +63,15 @@ void dump_transition() noexcept {
   }
 
   if (has_event) {
-    std::cout << " " << typeid(typename T::event).name();
+    std::cout << " " << boost::sml::aux::get_type_name<typename T::event>();
   }
 
   if (has_guard) {
-    std::cout << " [" << typeid(typename T::guard).name() << "]";
+    std::cout << " [" << boost::sml::aux::get_type_name<typename T::guard::type>() << "]";
   }
 
   if (has_action) {
-    std::cout << " / " << typeid(typename T::action).name();
+    std::cout << " / " << boost::sml::aux::get_type_name<typename T::action::type>();
   }
 
   std::cout << std::endl;
@@ -89,7 +88,6 @@ void dump(const SM&) noexcept {
   std::cout << "@startuml" << std::endl << std::endl;
   dump_transitions(typename SM::transitions{});
   std::cout << std::endl << "@enduml" << std::endl;
-}
 }
 
 int main() {

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -428,6 +428,7 @@ constexpr int max() {
 #endif
 template <class TExpr, class = void>
 struct zero_wrapper : TExpr {
+  using type = TExpr;
   explicit zero_wrapper(const TExpr &expr) : TExpr(expr) {}
   const TExpr &get() const { return *this; }
 };
@@ -441,6 +442,7 @@ struct zero_wrapper_impl<TExpr, type_list<TArgs...>> {
 template <class TExpr>
 struct zero_wrapper<TExpr, void_t<decltype(+declval<TExpr>())>>
     : zero_wrapper_impl<TExpr, function_traits_t<decltype(&TExpr::operator())>> {
+  using type = TExpr;
   template <class... Ts>
   zero_wrapper(Ts &&...) {}
   const TExpr &get() const { return reinterpret_cast<const TExpr &>(*this); }
@@ -2076,10 +2078,12 @@ struct get_deps<T<Ts...>, E, aux::enable_if_t<aux::is_base_of<operator_base, T<T
   using type = aux::join_t<get_deps_t<Ts, E>...>;
 };
 struct always {
+  using type = always;
   bool operator()() const { return true; }
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };
 struct none {
+  using type = none;
   void operator()() {}
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };

--- a/include/boost/sml/aux_/utility.hpp
+++ b/include/boost/sml/aux_/utility.hpp
@@ -273,6 +273,7 @@ constexpr int max() {
 
 template <class TExpr, class = void>
 struct zero_wrapper : TExpr {
+  using type = TExpr;
   explicit zero_wrapper(const TExpr &expr) : TExpr(expr) {}
   const TExpr &get() const { return *this; }
 };
@@ -289,6 +290,7 @@ struct zero_wrapper_impl<TExpr, type_list<TArgs...>> {
 template <class TExpr>
 struct zero_wrapper<TExpr, void_t<decltype(+declval<TExpr>())>>
     : zero_wrapper_impl<TExpr, function_traits_t<decltype(&TExpr::operator())>> {
+  using type = TExpr;
   template <class... Ts>
   zero_wrapper(Ts &&...) {}
   const TExpr &get() const { return reinterpret_cast<const TExpr &>(*this); }

--- a/include/boost/sml/front/transition.hpp
+++ b/include/boost/sml/front/transition.hpp
@@ -46,11 +46,13 @@ struct get_deps<T<Ts...>, E, aux::enable_if_t<aux::is_base_of<operator_base, T<T
 };
 
 struct always {
+  using type = always;
   bool operator()() const { return true; }
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };
 
 struct none {
+  using type = none;
   void operator()() {}
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };


### PR DESCRIPTION
…th gcc 7.3.0

Problem:
- Too much output is produced in the plant uml exmaple.

Solution:
- Apply `get_type_name combined with the underlying type of guards/actions.