### PR TITLE
sm move assignment operator

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1552,6 +1552,11 @@ class sm {
   sm(aux::init, deps_t &deps) : deps_{deps}, sub_sms_{deps} { aux::get<sm_impl<TSM>>(sub_sms_).start(deps_, sub_sms_); }
   sm(sm &&other) : deps_{other.deps_}, sub_sms_{other.deps_} {}
   sm(const sm &) = delete;
+  sm &operator=(sm &&other) {
+    deps_ = other.deps_;
+    sub_sms_ = other.sub_sms_;
+    return *this;
+  }
   sm &operator=(const sm &) = delete;
   template <class TEvent, __BOOST_SML_REQUIRES(aux::is_base_of<TEvent, events_ids>::value)>
   void process_event(const TEvent &event) {

--- a/test/ft/state_machine.cpp
+++ b/test/ft/state_machine.cpp
@@ -71,6 +71,36 @@ test sm_ctor_in_array = [] {
   (void)sms;
 };
 
+#if !defined(_MSC_VER)
+test sm_move_assignment = [] {
+  using namespace sml;
+
+  struct c {
+    auto operator()() noexcept {
+      // clang-format off
+      return make_transition_table(
+        *"A"_s + "e1"_e = "B"_s
+        ,"B"_s + "e2"_e = "C"_s
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c> sm1{};
+  sm1.process_event("e1"_e());
+  expect(sm1.is("B"_s));
+
+  sml::sm<c> sm2{};
+  sm2.process_event("e1"_e());
+  sm2.process_event("e2"_e());
+  expect(sm2.is("C"_s));
+
+  sm2 = std::move(sm1);
+  expect(sm1.is("B"_s));
+  expect(sm2.is("B"_s));
+};
+#endif
+
 test sm_events = [] {
   struct c {
     auto operator()() noexcept {


### PR DESCRIPTION
I'm not very happy with the semantics (current move ctor actually copies and this move assignment does the same) however this makes e.g. SM reset much cleaner (by assignment a fresh instance).