### PR TITLE
Add constexpr for event and state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ test/ft/exceptions.out:
 test/ft/policies_thread_safe.out: #-fsanitize=thread
 	$(CXX) test/ft/policies_thread_safe.cpp $(CXXFLAGS) $(DISABLE_EXCEPTIONS) -lpthread $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/policies_thread_safe.out && $($(MEMCHECK)) test/ft/policies_thread_safe.out
 
+test/ft/constexpr.out:
+	$(CXX) test/ft/constexpr.cpp $(CXXFLAGS) -ftemplate-depth=1024 $(DISABLE_EXCEPTIONS) $($(COVERAGE)) $(INCLUDE_TEST) -o test/ft/constexpr.out && $($(MEMCHECK)) test/ft/constexpr.out
+
 test/unit/%.out:
 	$(CXX) test/unit/unit1.cpp test/unit/unit2.cpp test/unit/units.cpp $(CXXFLAGS) $(DISABLE_EXCEPTIONS) $($(COVERAGE)) -o test/unit/units.out
 

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2492,8 +2492,12 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
 };
 }
 using _ = back::_;
+#if !defined(_MSC_VER)
 template <class TEvent>
-constexpr front::event<TEvent> event = {};
+constexpr front::event<TEvent> event{};
+#else
+front::event<TEvent> event{};
+#endif
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
 template <class TEvent>
@@ -2504,8 +2508,13 @@ template <class T>
 front::event<back::exception<T>> exception __BOOST_SML_VT_INIT;
 using anonymous = back::anonymous;
 using initial = back::initial;
+#if !defined(_MSC_VER)
 template <class T>
-constexpr typename front::state_sm<T>::type state = {};
+constexpr typename front::state_sm<T>::type state{};
+#else
+template <class T>
+typename front::state_sm<T>::type state{};
+#endif
 #if !defined(_MSC_VER)
 template <class T, T... Chrs>
 constexpr auto operator""_s() {

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2493,7 +2493,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
 }
 using _ = back::_;
 template <class TEvent>
-front::event<TEvent> event __BOOST_SML_VT_INIT;
+constexpr front::event<TEvent> event __BOOST_SML_VT_INIT;
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
 template <class TEvent>
@@ -2505,14 +2505,14 @@ front::event<back::exception<T>> exception __BOOST_SML_VT_INIT;
 using anonymous = back::anonymous;
 using initial = back::initial;
 template <class T>
-typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
+constexpr typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #if !defined(_MSC_VER)
 template <class T, T... Chrs>
-auto operator""_s() {
+constexpr auto operator""_s() {
   return front::state<aux::string<T, Chrs...>>{};
 }
 template <class T, T... Chrs>
-auto operator""_e() {
+constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
 #endif

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2496,6 +2496,7 @@ using _ = back::_;
 template <class TEvent>
 constexpr front::event<TEvent> event{};
 #else
+template <class TEvent>
 front::event<TEvent> event __BOOST_SML_VT_INIT;
 #endif
 template <class TEvent>

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2493,7 +2493,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
 }
 using _ = back::_;
 template <class TEvent>
-constexpr front::event<TEvent> event{};
+constexpr front::event<TEvent> event = {};
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
 template <class TEvent>
@@ -2505,7 +2505,7 @@ front::event<back::exception<T>> exception __BOOST_SML_VT_INIT;
 using anonymous = back::anonymous;
 using initial = back::initial;
 template <class T>
-constexpr typename front::state_sm<T>::type state{};
+constexpr typename front::state_sm<T>::type state = {};
 #if !defined(_MSC_VER)
 template <class T, T... Chrs>
 constexpr auto operator""_s() {

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2496,7 +2496,7 @@ using _ = back::_;
 template <class TEvent>
 constexpr front::event<TEvent> event{};
 #else
-front::event<TEvent> event{};
+front::event<TEvent> event __BOOST_SML_VT_INIT;
 #endif
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
@@ -2513,7 +2513,7 @@ template <class T>
 constexpr typename front::state_sm<T>::type state{};
 #else
 template <class T>
-typename front::state_sm<T>::type state{};
+typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #endif
 #if !defined(_MSC_VER)
 template <class T, T... Chrs>

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2493,7 +2493,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
 }
 using _ = back::_;
 template <class TEvent>
-constexpr front::event<TEvent> event __BOOST_SML_VT_INIT;
+constexpr front::event<TEvent> event{};
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
 template <class TEvent>
@@ -2505,7 +2505,7 @@ front::event<back::exception<T>> exception __BOOST_SML_VT_INIT;
 using anonymous = back::anonymous;
 using initial = back::initial;
 template <class T>
-constexpr typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
+constexpr typename front::state_sm<T>::type state{};
 #if !defined(_MSC_VER)
 template <class T, T... Chrs>
 constexpr auto operator""_s() {

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -406,6 +406,11 @@ class sm {
   sm(sm &&other) : deps_{other.deps_}, sub_sms_{other.deps_} {}
 
   sm(const sm &) = delete;
+  sm &operator=(sm &&other) {
+    deps_ = other.deps_;
+    sub_sms_ = other.sub_sms_;
+    return *this;
+  }
   sm &operator=(const sm &) = delete;
 
   template <class TEvent, __BOOST_SML_REQUIRES(aux::is_base_of<TEvent, events_ids>::value)>

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -24,7 +24,7 @@ using _ = back::_;
 #if !defined(_MSC_VER)  // __pph__
 template <class TEvent>
 constexpr front::event<TEvent> event{};
-#else  // __pph__
+#else   // __pph__
 template <class TEvent>
 front::event<TEvent> event __BOOST_SML_VT_INIT;
 #endif  // __pph__
@@ -49,7 +49,7 @@ using initial = back::initial;
 #if !defined(_MSC_VER)  // __pph__
 template <class T>
 constexpr typename front::state_sm<T>::type state{};
-#else  // __pph__
+#else   // __pph__
 template <class T>
 typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #endif  // __pph__

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -21,12 +21,12 @@ using _ = back::_;
 
 /// events
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER)  // __pph__
 template <class TEvent>
 constexpr front::event<TEvent> event{};
-#else
-front::event<TEvent> event{};
-#endif
+#else  // __pph__
+front::event<TEvent> event __BOOST_SML_VT_INIT;
+#endif  // __pph__
 
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
@@ -45,13 +45,13 @@ using initial = back::initial;
 
 /// states
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER)  // __pph__
 template <class T>
 constexpr typename front::state_sm<T>::type state{};
-#else
+#else  // __pph__
 template <class T>
-typename front::state_sm<T>::type state{};
-#endif
+typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
+#endif  // __pph__
 
 #if !defined(_MSC_VER)  // __pph__
 template <class T, T... Chrs>

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -25,6 +25,7 @@ using _ = back::_;
 template <class TEvent>
 constexpr front::event<TEvent> event{};
 #else  // __pph__
+template <class TEvent>
 front::event<TEvent> event __BOOST_SML_VT_INIT;
 #endif  // __pph__
 

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -22,7 +22,7 @@ using _ = back::_;
 /// events
 
 template <class TEvent>
-constexpr front::event<TEvent> event{};
+constexpr front::event<TEvent> event = {};
 
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
@@ -42,7 +42,7 @@ using initial = back::initial;
 /// states
 
 template <class T>
-constexpr typename front::state_sm<T>::type state{};
+constexpr typename front::state_sm<T>::type state = {};
 
 #if !defined(_MSC_VER)  // __pph__
 template <class T, T... Chrs>

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -42,11 +42,11 @@ using initial = back::initial;
 /// states
 
 template <class T>
-typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
+constexpr typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 
 #if !defined(_MSC_VER)  // __pph__
 template <class T, T... Chrs>
-auto operator""_s() {
+constexpr auto operator""_s() {
   return front::state<aux::string<T, Chrs...>>{};
 }
 template <class T, T... Chrs>

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -21,8 +21,12 @@ using _ = back::_;
 
 /// events
 
+#if !defined(_MSC_VER)
 template <class TEvent>
-constexpr front::event<TEvent> event = {};
+constexpr front::event<TEvent> event{};
+#else
+front::event<TEvent> event{};
+#endif
 
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
@@ -41,8 +45,13 @@ using initial = back::initial;
 
 /// states
 
+#if !defined(_MSC_VER)
 template <class T>
-constexpr typename front::state_sm<T>::type state = {};
+constexpr typename front::state_sm<T>::type state{};
+#else
+template <class T>
+typename front::state_sm<T>::type state{};
+#endif
 
 #if !defined(_MSC_VER)  // __pph__
 template <class T, T... Chrs>

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -22,7 +22,7 @@ using _ = back::_;
 /// events
 
 template <class TEvent>
-front::event<TEvent> event __BOOST_SML_VT_INIT;
+constexpr front::event<TEvent> event __BOOST_SML_VT_INIT;
 
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
@@ -50,7 +50,7 @@ constexpr auto operator""_s() {
   return front::state<aux::string<T, Chrs...>>{};
 }
 template <class T, T... Chrs>
-auto operator""_e() {
+constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
 #endif  // __pph__

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -22,7 +22,7 @@ using _ = back::_;
 /// events
 
 template <class TEvent>
-constexpr front::event<TEvent> event __BOOST_SML_VT_INIT;
+constexpr front::event<TEvent> event{};
 
 template <class TEvent>
 __BOOST_SML_UNUSED front::event<back::on_entry<_, TEvent>> on_entry __BOOST_SML_VT_INIT;
@@ -42,7 +42,7 @@ using initial = back::initial;
 /// states
 
 template <class T>
-constexpr typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
+constexpr typename front::state_sm<T>::type state{};
 
 #if !defined(_MSC_VER)  // __pph__
 template <class T, T... Chrs>

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -70,6 +70,9 @@ endif ()
 add_executable(test_sizeof sizeof.cpp)
 add_test(test_sizeof test_sizeof)
 
+add_executable(test_constexpr constexpr.cpp)
+add_test(test_constexpr test_constexpr)
+
 # include\boost/sml.hpp(1330): error C3779: 'c::operator ()': a function that returns 'auto' cannot be used before it is defined
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # gcc
     add_executable(test_state_machine state_machine.cpp)

--- a/test/ft/constexpr.cpp
+++ b/test/ft/constexpr.cpp
@@ -38,7 +38,8 @@ test terminate_state = [] {
       // clang-format off
       return make_transition_table(
          *idle + event1 = s1
-        , s1 + event2 = X
+        , s1 + event1 = s2
+        , s2 + event2 = X
       );
       // clang-format on
     }
@@ -48,6 +49,8 @@ test terminate_state = [] {
   expect(sm.is(idle));
   sm.process_event(event1());
   expect(sm.is(s1));
+  sm.process_event(event1());
+  expect(sm.is(s2));
   sm.process_event(e2{});
   expect(sm.is(sml::X));
 };

--- a/test/ft/constexpr.cpp
+++ b/test/ft/constexpr.cpp
@@ -26,7 +26,7 @@ using namespace sml;
 constexpr auto s2 = "s2"_s;
 constexpr auto event1 = "e1"_e;
 #else
-constexpr auto s2 = event<e2>;
+constexpr auto s2 = state<e2>;
 constexpr auto event1 = event<e1>;
 #endif
 

--- a/test/ft/constexpr.cpp
+++ b/test/ft/constexpr.cpp
@@ -5,6 +5,9 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+//
+#if !defined(_MSC_VER)
+
 #include <boost/sml.hpp>
 #include <string>
 #include <typeindex>
@@ -21,14 +24,8 @@ constexpr auto idle = sml::state<class idle>;
 constexpr auto s1 = sml::front::state<class s1>{};
 
 using namespace sml;
-#if !defined(_MSC_VER)
 constexpr auto s2 = "s2"_s;
 constexpr auto event1 = "e1"_e;
-#else
-constexpr auto s2 = state<e2>;
-constexpr auto event1 = event<e1>;
-#endif
-
 constexpr auto event2 = front::event<e2>{};
 
 test terminate_state = [] {
@@ -53,3 +50,5 @@ test terminate_state = [] {
   sm.process_event(e2{});
   expect(sm.is(sml::X));
 };
+
+#endif

--- a/test/ft/constexpr.cpp
+++ b/test/ft/constexpr.cpp
@@ -17,7 +17,6 @@ namespace sml = boost::sml;
 struct e1 {};
 struct e2 {};
 
-
 constexpr auto idle = sml::state<class idle>;
 constexpr auto s1 = sml::front::state<class s1>{};
 
@@ -54,4 +53,3 @@ test terminate_state = [] {
   sm.process_event(e2{});
   expect(sm.is(sml::X));
 };
-

--- a/test/ft/constexpr.cpp
+++ b/test/ft/constexpr.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2016-2018 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/sml.hpp>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+namespace sml = boost::sml;
+
+struct e1 {};
+struct e2 {};
+struct e3 {};
+
+constexpr auto idle = sml::state<class idle>;
+constexpr auto s1 = sml::front::state<class s1>{};
+using namespace sml;
+constexpr auto s2 = "s2"_s;
+
+test terminate_state = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *idle + event<e1> = s1
+        , s1 + event<e2> = X
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c> sm;
+  expect(sm.is(idle));
+  sm.process_event(e1{});
+  expect(sm.is(s1));
+  sm.process_event(e2{});
+  expect(sm.is(sml::X));
+  sm.process_event(e1{});
+  sm.process_event(e2{});
+  sm.process_event(e3{});
+  expect(sm.is(sml::X));
+};
+

--- a/test/ft/constexpr.cpp
+++ b/test/ft/constexpr.cpp
@@ -16,21 +16,29 @@ namespace sml = boost::sml;
 
 struct e1 {};
 struct e2 {};
-struct e3 {};
+
 
 constexpr auto idle = sml::state<class idle>;
 constexpr auto s1 = sml::front::state<class s1>{};
+
 using namespace sml;
+#if !defined(_MSC_VER)
 constexpr auto s2 = "s2"_s;
+constexpr auto event1 = "e1"_e;
+#else
+constexpr auto s2 = event<e2>;
+constexpr auto event1 = event<e1>;
+#endif
+
+constexpr auto event2 = front::event<e2>{};
 
 test terminate_state = [] {
   struct c {
     auto operator()() noexcept {
-      using namespace sml;
       // clang-format off
       return make_transition_table(
-         *idle + event<e1> = s1
-        , s1 + event<e2> = X
+         *idle + event1 = s1
+        , s1 + event2 = X
       );
       // clang-format on
     }
@@ -38,13 +46,9 @@ test terminate_state = [] {
 
   sml::sm<c> sm;
   expect(sm.is(idle));
-  sm.process_event(e1{});
+  sm.process_event(event1());
   expect(sm.is(s1));
   sm.process_event(e2{});
-  expect(sm.is(sml::X));
-  sm.process_event(e1{});
-  sm.process_event(e2{});
-  sm.process_event(e3{});
   expect(sm.is(sml::X));
 };
 

--- a/test/ft/sizeof.cpp
+++ b/test/ft/sizeof.cpp
@@ -50,17 +50,17 @@ test transition_sizeof = [] {
   }
 
   {
-    auto t = "state"_s + "event"_e[([i] {})] / [] {};
+    auto t = "state"_s + "event"_e[([i] {(void)i;})] / [] {};
     static_expect(sizeof(i) == sizeof(t));
   }
 
   {
-    auto t = "state"_s + "event"_e[([] {})] / [i] {};
+    auto t = "state"_s + "event"_e[([] {})] / [i] {(void)i;};
     static_expect(sizeof(i) == sizeof(t));
   }
 
   {
-    auto t = "state"_s + "event"_e[([] {})] / [&i] {};
+    auto t = "state"_s + "event"_e[([] {})] / [&i] {(void)i;};
     static_expect(sizeof(&i) == sizeof(t));
   }
 };

--- a/test/ft/sizeof.cpp
+++ b/test/ft/sizeof.cpp
@@ -50,17 +50,17 @@ test transition_sizeof = [] {
   }
 
   {
-    auto t = "state"_s + "event"_e[([i] {(void)i;})] / [] {};
+    auto t = "state"_s + "event"_e[([i] { (void)i; })] / [] {};
     static_expect(sizeof(i) == sizeof(t));
   }
 
   {
-    auto t = "state"_s + "event"_e[([] {})] / [i] {(void)i;};
+    auto t = "state"_s + "event"_e[([] {})] / [i] { (void)i; };
     static_expect(sizeof(i) == sizeof(t));
   }
 
   {
-    auto t = "state"_s + "event"_e[([] {})] / [&i] {(void)i;};
+    auto t = "state"_s + "event"_e[([] {})] / [&i] { (void)i; };
     static_expect(sizeof(&i) == sizeof(t));
   }
 };


### PR DESCRIPTION
Fixes fuchsia-statically-constructed-objects warning in clang-tidy when doing something like this:

```c++
constexpr auto my_state = boost::sml::event<class MyState>;
using namespace boost::sml;
constexpr auto my_event = "event1"_e;
```

Tested on clang and gcc only.