### PR TITLE
cmake: install headers and added options to disable targets build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,13 +97,21 @@ if(NOT (DEFINED CMAKE_CXX_STANDARD) OR CMAKE_CXX_STANDARD STREQUAL "" OR CMAKE_C
     message(FATAL_ERROR "sml requires c++14")
 endif()
 
+include(GNUInstallDirs)
+install(DIRECTORY "include/boost" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+if(NOT (BUILD_BENCHMARKS OR BUILD_DOCS OR BUILD_EXAMPLES OR BUILD_TESTS))
+    message(STATUS "No targets will be built")
+    return()
+endif()
+
 set(CXX_STANDARD_REQUIRED ON)
 message(STATUS "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
 
 # Turn on the .vcproj folder support
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-find_package(Boost          REQUIRED)
+find_package(Boost REQUIRED)
 
 include_directories(AFTER
     ${Boost_INCLUDE_DIR}
@@ -152,7 +160,3 @@ endif ()
 if (BUILD_TESTS)
     add_subdirectory(test)
 endif ()
-
-include(GNUInstallDirs)
-install(DIRECTORY "include/boost" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ message(STATUS "cmake version: ${CMAKE_VERSION}")
 project(sml LANGUAGES CXX)
 include(CTest)
 
+option(BUILD_BENCHMARKS "Build benchmarks" ON)
+option(BUILD_DOCS       "Build docs"       ON)
+option(BUILD_EXAMPLES   "Build examples"   ON)
+option(BUILD_TESTS      "Build tests"      ON)
+
 # sml use hana library, according to hana documentation GCC >= 6.0.0
 # http://www.boost.org/doc/libs/release/libs/hana/doc/html/index.html#tutorial-installation-requirements
 # https://github.com/boostorg/hana/wiki/General-notes-on-compiler-support
@@ -135,7 +140,15 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # gcc
     endif ()
 endif ()
 
-add_subdirectory(benchmark)
-add_subdirectory(doc)
-add_subdirectory(example)
-add_subdirectory(test)
+if (BUILD_BENCHMARKS)
+    add_subdirectory(benchmark)
+endif ()
+if (BUILD_DOCS)
+    add_subdirectory(doc)
+endif ()
+if (BUILD_EXAMPLES)
+    add_subdirectory(example)
+endif ()
+if (BUILD_TESTS)
+    add_subdirectory(test)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,3 +152,7 @@ endif ()
 if (BUILD_TESTS)
     add_subdirectory(test)
 endif ()
+
+include(GNUInstallDirs)
+install(DIRECTORY "include/boost" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+


### PR DESCRIPTION
This makes possible to use the library as cmake external project
(instead of [manually downloading the header](http://boost-experimental.github.io/sml/overview/index.html#quick-start))

### Demo

* `CMakeLists.txt`

```cmake
cmake_minimum_required(VERSION 3.12)
project(test)

include(ExternalProject)
ExternalProject_Add(external_boost_sml
        PREFIX "${CMAKE_BINARY_DIR}/external-projects"
        GIT_REPOSITORY "https://github.com/arteniioleg/sml.git"
        GIT_TAG "master"
        CMAKE_ARGS
        -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external-projects/installed
        -DBUILD_BENCHMARKS=OFF
        -DBUILD_DOCS=OFF
        -DBUILD_EXAMPLES=OFF
        -DBUILD_TESTS=OFF
        )
set_target_properties(external_boost_sml PROPERTIES EXCLUDE_FROM_ALL TRUE)

add_executable(${PROJECT_NAME} main.cpp)
add_dependencies(${PROJECT_NAME} external_boost_sml) # comment to prevent build on each build

include(GNUInstallDirs)
target_include_directories(${PROJECT_NAME}
        PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/external-projects/installed/${CMAKE_INSTALL_INCLUDEDIR}>)
```

* `main.cpp`

```cpp
#include <boost/sml.hpp>
#include <iostream>

int main() {
    std::cout << boost::sml::back::anonymous::c_str() << std::endl;
    return 0;
}
```