### PR TITLE
:bug: Process all anonymous transitions

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -2283,6 +2283,14 @@ void update_current_state(SM &, TDeps &deps, TSubs &subs, typename SM::state_t &
   update_composite_states<back::sm_impl<T>>(subs, typename back::sm_impl<T>::has_history_states{},
                                             typename back::sm_impl<T>::history_states_t{});
 }
+template <class TDeps, class TSubs, class TDstState>
+void process_internal_transitions(TDeps &, TSubs &, const TDstState &) {}
+template <class TDeps, class TSubs, class T>
+void process_internal_transitions(TDeps &deps, TSubs &subs, const state<back::sm<T>> &) {
+  auto &sm = back::sub_sm<back::sm_impl<T>>::get(&subs);
+  while (sm.process_internal_events(back::anonymous{}, deps, subs)) {
+  }
+}
 template <class S1, class S2, class E, class G, class A>
 struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
   static constexpr auto initial = state<S2>::initial;
@@ -2303,6 +2311,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
                            state<dst_state>{});
       call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
       sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -2314,6 +2323,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
       call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -2362,6 +2372,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, A> {
                          state<dst_state>{});
     call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
     sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
   template <class TEvent, class SM, class TDeps, class TSubs>
@@ -2370,6 +2381,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, A> {
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
     call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
   A a;
@@ -2411,6 +2423,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, none> {
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
       sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -2421,6 +2434,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, none> {
       update_current_state(sm, deps, subs, current_state,
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -2462,6 +2476,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, none> {
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
     sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
   template <class TEvent, class SM, class TDeps, class TSubs>
@@ -2469,6 +2484,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, none> {
     update_current_state(sm, deps, subs, current_state,
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -85,7 +85,8 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
     const auto handled =
         process_event_noexcept<get_event_mapping_t<get_generic_t<TEvent>, mappings>>(event, deps, subs, has_exceptions{});
 #endif  // __pph__
-    process_internal_events(anonymous{}, deps, subs);
+    // Repeat internal transition until there is no more to process.
+    while(process_internal_events(anonymous{}, deps, subs)){}
     process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{});
     process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{});
 
@@ -111,8 +112,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 
   template <class TDeps, class TSubs>
   void start(TDeps &deps, TSubs &subs) {
+    
     process_internal_events(on_entry<_, initial>{}, deps, subs);
-    process_internal_events(anonymous{}, deps, subs);
+    while(process_internal_events(anonymous{}, deps, subs)) {}
     process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{});
   }
 

--- a/include/boost/sml/back/transitions.hpp
+++ b/include/boost/sml/back/transitions.hpp
@@ -107,8 +107,7 @@ template <class TSM>
 struct transitions_sub<sm<TSM>> {
   template <class TEvent, class SM, class TDeps, class TSubs>
   static bool execute(const TEvent& event, SM&, TDeps& deps, TSubs& subs, typename SM::state_t&) {
-    sub_sm<sm_impl<TSM>>::get(&subs).template process_event<TEvent>(event, deps, subs);
-    return true;
+    return sub_sm<sm_impl<TSM>>::get(&subs).template process_event<TEvent>(event, deps, subs);
   }
 };
 

--- a/include/boost/sml/front/transition.hpp
+++ b/include/boost/sml/front/transition.hpp
@@ -272,6 +272,15 @@ void update_current_state(SM &, TDeps &deps, TSubs &subs, typename SM::state_t &
                                             typename back::sm_impl<T>::history_states_t{});
 }
 
+template <class TDeps, class TSubs, class TDstState>
+void process_internal_transitions(TDeps &, TSubs &, const TDstState &) {}
+
+template <class TDeps, class TSubs, class T>
+void process_internal_transitions(TDeps &deps, TSubs &subs, const state<back::sm<T>> &) {
+  auto& sm = back::sub_sm<back::sm_impl<T>>::get(&subs);
+  while(sm.process_internal_events(back::anonymous{}, deps, subs)) {}
+}
+
 template <class S1, class S2, class E, class G, class A>
 struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
   static constexpr auto initial = state<S2>::initial;
@@ -295,6 +304,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
                            state<dst_state>{});
       call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
       sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -307,6 +317,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, A> {
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
       call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -365,6 +376,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, A> {
                          state<dst_state>{});
     call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
     sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 
@@ -374,6 +386,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, A> {
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
     call<TEvent, args_t<A, TEvent>, typename SM::logger_t>::execute(a, event, sm, deps, subs);
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 
@@ -425,6 +438,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, none> {
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
       sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -436,6 +450,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, G, none> {
       update_current_state(sm, deps, subs, current_state,
                            aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                            state<dst_state>{});
+      process_internal_transitions(deps, subs, state<dst_state>{});
       return true;
     }
     return false;
@@ -487,6 +502,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, none> {
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
     sm.process_internal_event(back::on_entry<back::_, TEvent>{event}, deps, subs, current_state);
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 
@@ -495,6 +511,7 @@ struct transition<state<S1>, state<S2>, front::event<E>, always, none> {
     update_current_state(sm, deps, subs, current_state,
                          aux::get_id<typename SM::state_t, dst_state>((typename SM::states_ids_t *)0), state<src_state>{},
                          state<dst_state>{});
+    process_internal_transitions(deps, subs, state<dst_state>{});
     return true;
   }
 

--- a/test/ft/transition_table.cpp
+++ b/test/ft/transition_table.cpp
@@ -131,15 +131,12 @@ test transition_table_types = [] {
          *idle + event<e1> [guard1] / (action1, []{}) = s1
         , s1 + event<e2> / ([] { }) = s2
         , s2 + event<e4> / defer
-        , s1 / [] {}
-        , s1 [guard1 && guard3(42)]
-        , s1 [guard1] / action1
         , s1 + event<e3> / action1
-        , idle = s1
+        , idle [guard3(42)] = s1
         , s3 + event<e4> / [] { }
         , s3 + event<e5> [guard1] / action1
         , s1 [guard1 && guard1 && [] { return true; }] = s2
-        , (*s3) [guard1] = s2
+        , (*s3) [guard1] = s4
         , s2 [guard1 && !guard2] = s3
         , s3 [guard1] / action1 = s4
         , s4 / action1 = s5
@@ -162,10 +159,9 @@ test transition_table_types = [] {
         , s2 <= s1 + event<e2> / ([] { })
         , s1 <= s2 + event<e4> / defer
         , s2 <= s1 [guard1 && guard1 && [] { return true; }]
-        , s2 <= (*s3) [guard1]
-        , s2 <= s3 [guard1 && !guard2]
-        , s3 <= s4 [guard1] / action1
-        , s4 <= s5 / action1
+        , s4 <= (*s3) [guard1]
+        , s4 <= s3 [guard1 && !guard2]
+        , s5 <= s4 [guard1] / action1
         , end <= s5 / (action1, action2)
         , s1 <= idle(H) + event<e1>
         , s1 <= idle(H) + event<e1> [c_guard{} && guard1]

--- a/test/ft/transitions.cpp
+++ b/test/ft/transitions.cpp
@@ -87,6 +87,27 @@ test anonymous_transition = [] {
   expect(static_cast<const c&>(sm).a_called);
 };
 
+test subsequent_anonymous_transitions = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+       *idle / [this] { a_calls.push_back(1); } = s1
+       ,s1 / [this] { a_calls.push_back(2); } = s2
+       ,s2 / [this] { a_calls.push_back(3); } = s3
+      );
+      // clang-format on
+    }
+
+    std::vector<int> a_calls{};
+  };
+
+  sml::sm<c> sm{};
+  expect(sm.is(s3));
+  expect(static_cast<const c&>(sm).a_calls == std::vector<int>{{1, 2, 3}});
+};
+
 test self_transition = [] {
   enum class calls { s1_entry, s1_exit, s1_action };
 


### PR DESCRIPTION
Problem:
- Anonymous transitions after the first one are not processed.
Solution:
- Process them until there is nothing to do.