### PR TITLE
Fixed #230.

### DIFF
--- a/doc/embo-2018/index.html
+++ b/doc/embo-2018/index.html
@@ -1398,7 +1398,7 @@ struct System {
 * If deferred event can't be handled it stays in the queue
 * [Boost].SML requires defer_queue policy
   ```cpp
-  sml::sm<System, sml::defer_queue<std::queue>> sm{};
+  sml::sm<System, sml::defer_queue<std::deque>> sm{};
   ```
 
 ----

--- a/example/defer_and_process.cpp
+++ b/example/defer_and_process.cpp
@@ -7,6 +7,7 @@
 //
 #include <boost/sml.hpp>
 #include <cassert>
+#include <deque>
 #include <queue>
 
 namespace sml = boost::sml;
@@ -35,7 +36,7 @@ struct defer_and_process {
 
 int main() {
   using namespace sml;
-  sm<defer_and_process, sml::defer_queue<std::queue>, sml::process_queue<std::queue>>
+  sm<defer_and_process, sml::defer_queue<std::deque>, sml::process_queue<std::queue>>
       sm;  /// defer_queue policy to enable deferred events using std::queue
   assert(sm.is("idle"_s));
 

--- a/include/boost/sml/back/internals.hpp
+++ b/include/boost/sml/back/internals.hpp
@@ -105,8 +105,8 @@ struct process : queue_handler<TEvents...> {
 };
 
 template <class... TEvents>
-struct defer : queue_handler<TEvents...> {
-  using queue_handler<TEvents...>::queue_handler;
+struct defer : deque_handler<TEvents...> {
+  using deque_handler<TEvents...>::deque_handler;
 };
 
 }  // namespace back

--- a/include/boost/sml/back/policies.hpp
+++ b/include/boost/sml/back/policies.hpp
@@ -24,6 +24,8 @@ struct no_policy : policies::thread_safety_policy__ {
   using rebind = no_policy;
   template <class...>
   using defer = no_policy;
+  using const_iterator = no_policy;
+  using flag = no_policy;
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };
 

--- a/include/boost/sml/back/policies/defer_queue.hpp
+++ b/include/boost/sml/back/policies/defer_queue.hpp
@@ -18,6 +18,7 @@ template <template <class...> class T>
 struct defer_queue : aux::pair<back::policies::defer_queue_policy__, defer_queue<T>> {
   template <class U>
   using rebind = T<U>;
+  using flag = bool;
 };
 
 }  // namespace policies

--- a/include/boost/sml/front/actions/defer.hpp
+++ b/include/boost/sml/front/actions/defer.hpp
@@ -15,7 +15,12 @@ namespace actions {
 struct defer : action_base {
   template <class TEvent, class TSM, class TDeps, class TSubs>
   void operator()(const TEvent &event, TSM &sm, TDeps &, TSubs &) {
-    sm.defer_.push(event);
+    if (sm.defer_processing_) {
+      sm.defer_again_ = true;
+    }
+    else {
+      sm.defer_.push_back(event);
+    }
   }
 };
 


### PR DESCRIPTION
Remain the deferred event that from deferred_queue during the transition
process. Then, process the next deferred event. The event position is
not front(), so `std::queue` concept doesn't satisfies it. I need
iteration concept something like `std::deque`.

In order to do that, I introduced two flags that are `defer_processing_`
and `defer_again_`. In addition, to iterate deferred deque, two
iterators `defer_it_` and `defer_end_` are introduced.