### PR TITLE
:wrench: :arrow_up: [travis/appveyor] Update compilers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,13 @@ environment:
     MEMCHECK: DRMEMORY
     PLATFORM: amd64
 
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 15 2017
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 # Style
 #
   - os: linux
-    dist: precise
+    dist: trusty
     env: CHECK=ON CLANG_FORMAT=clang-format-4.0 CLANG_TIDY=clang-tidy-4.0
     addons: { apt: { packages: ["clang-format-4.0", "clang-tidy-4.0", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-4.0"] } }
 
@@ -43,37 +43,52 @@ matrix:
     addons: { apt: { packages: ["clang-3.7", "libstdc++-5-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.7"] } }
 
   - os: linux
-    dist: precise
+    dist: trusty
     env: CXX=clang++-3.8 MEMCHECK=VALGRIND
     addons: { apt: { packages: ["clang-3.8", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.8"] } }
 
   - os: linux
-    dist: precise
+    dist: trusty
     env: CXX=clang++-3.9 MEMCHECK=VALGRIND
-    addons: { apt: { packages: ["clang-3.9", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-precise-3.9"] } }
+    addons: { apt: { packages: ["clang-3.9", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-3.9"] } }
 
   - os: linux
-    dist: precise
+    dist: trusty
     env: CXX=clang++-4.0 MEMCHECK=VALGRIND
     addons: { apt: { packages: ["clang-4.0", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-4.0"] } }
 
   - os: linux
-    dist: precise
-    env: CXX=clang++-4.0 LIBCXX=ON MEMCHECK=VALGRIND
-    addons: { apt: { packages: ["clang-4.0", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-4.0"] } }
+    dist: trusty
+    env: CXX=clang++-5.0 MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-5.0", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-5.0"] } }
 
   - os: linux
-    dist: precise
-    env: CXX=clang++-4.0 CXXSTD=c++1z LIBCXX=ON MEMCHECK=VALGRIND
-    addons: { apt: { packages: ["clang-4.0", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-4.0"] } }
+    dist: trusty
+    env: CXX=clang++-6.0 MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-6.0", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-6.0"] } }
 
   - os: linux
-    dist: precise
+    dist: trusty
+    env: CXX=clang++-7 MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
+
+  - os: linux
+    dist: trusty
+    env: CXX=clang++-7 LIBCXX=ON MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
+
+  - os: linux
+    dist: trusty
+    env: CXX=clang++-7 CXXSTD=c++1z LIBCXX=ON MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
+
+  - os: linux
+    dist: trusty
     env: CXX=g++-5 MEMCHECK=VALGRIND
     addons: { apt: { packages: ["g++-5", "libstdc++-5-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: linux
-    dist: precise
+    dist: trusty
     env: CXX=g++-6 MEMCHECK=VALGRIND
     addons: { apt: { packages: ["g++-6", "libstdc++-6-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
@@ -84,8 +99,13 @@ matrix:
 
   - os: linux
     dist: trusty
-    env: CXX=g++-7 CXXSTD=c++1z MEMCHECK=VALGRIND
-    addons: { apt: { packages: ["g++-7", "libstdc++-7-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+    env: CXX=g++-8 MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+  - os: linux
+    dist: trusty
+    env: CXX=g++-8 CXXSTD=c++1z MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
     osx_image: xcode7.3
@@ -99,13 +119,21 @@ matrix:
     osx_image: xcode9.1
     env: CXX=clang++
 
+  - os: osx
+    osx_image: xcode10
+    env: XX=clang++
+
+  - os: osx
+    osx_image: xcode10.1
+    env: CXX=clang++
+
 #
 # Coverage
 #
   - os: linux
     dist: trusty
-    env: COVERAGE=GCOV CXX=g++-7
-    addons: { apt: { packages: ["g++-7", "libstdc++-7-dev"], sources: ["ubuntu-toolchain-r-test"] } }
+    env: COVERAGE=GCOV CXX=g++-8
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev"], sources: ["ubuntu-toolchain-r-test"] } }
 
 before_install:
   - git config --global user.name "Continuous Integration"

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -205,7 +205,7 @@ struct remove_reference<T &&> {
 };
 template <class T>
 using remove_reference_t = typename remove_reference<T>::type;
-}  // namespace aux
+}
 namespace aux {
 using swallow = int[];
 template <int...>
@@ -453,7 +453,7 @@ auto get_type_name(const char *ptr, index_sequence<Ns...>) {
   static const char str[] = {ptr[N + Ns]..., 0};
   return str;
 }
-}  // namespace detail
+}
 template <class T>
 const char *get_type_name() {
 #if defined(_MSC_VER)
@@ -484,7 +484,7 @@ struct string<T> {
   }
   static auto c_str_impl(...) { return get_type_name<T>(); }
 };
-}  // namespace aux
+}
 namespace back {
 namespace policies {
 struct defer_queue_policy__ {};
@@ -494,8 +494,8 @@ struct defer_queue : aux::pair<back::policies::defer_queue_policy__, defer_queue
   using rebind = T<U>;
   using flag = bool;
 };
-}  // namespace policies
-}  // namespace back
+}
+}
 namespace back {
 template <class... Ts>
 class queue_event {
@@ -579,7 +579,7 @@ struct deque_handler : queue_event_call<TEvents>... {
   }
   void *deque_{};
 };
-}  // namespace back
+}
 namespace back {
 struct _ {};
 struct initial {};
@@ -661,7 +661,7 @@ template <class... TEvents>
 struct defer : deque_handler<TEvents...> {
   using deque_handler<TEvents...>::deque_handler;
 };
-}  // namespace back
+}
 namespace back {
 template <class>
 class sm;
@@ -783,7 +783,7 @@ template <class T, class... Ts>
 struct convert_to_sm<T, aux::type_list<Ts...>> {
   using type = aux::type_list<sm_impl<T>, sm_impl<typename T::template rebind<Ts>>...>;
 };
-}  // namespace back
+}
 namespace back {
 template <class>
 class sm;
@@ -869,7 +869,7 @@ struct transitions_sub<sm<TSM>> {
     return sub_sm<sm_impl<TSM>>::get(&subs).template process_event<TEvent>(event, deps, subs);
   }
 };
-}  // namespace back
+}
 namespace back {
 template <class>
 class sm;
@@ -987,7 +987,7 @@ struct get_event_mapping_impl_helper<on_exit<T1, T2>, TMappings>
     : decltype(get_event_mapping_impl<on_exit<T1, T2>>((TMappings *)0)) {};
 template <class T, class TMappings>
 using get_event_mapping_t = get_event_mapping_impl_helper<T, TMappings>;
-}  // namespace back
+}
 namespace back {
 namespace policies {
 struct dispatch_policy__ {};
@@ -1062,8 +1062,8 @@ struct fold_expr {
   }
 };
 #endif
-}  // namespace policies
-}  // namespace back
+}
+}
 namespace back {
 template <class>
 class sm;
@@ -1130,8 +1130,8 @@ void log_guard(const aux::type<TLogger> &, TDeps &deps, const aux::zero_wrapper<
                bool result) {
   return static_cast<aux::pool_type<TLogger &> &>(deps).value.template log_guard<SM>(guard.get(), event, result);
 }
-}  // namespace policies
-}  // namespace back
+}
+}
 namespace back {
 namespace policies {
 struct process_queue_policy__ {};
@@ -1140,14 +1140,14 @@ struct process_queue : aux::pair<back::policies::process_queue_policy__, process
   template <class U>
   using rebind = T<U>;
 };
-}  // namespace policies
-}  // namespace back
+}
+}
 namespace back {
 namespace policies {
 struct testing_policy__ {};
 struct testing : aux::pair<testing_policy__, testing> {};
-}  // namespace policies
-}  // namespace back
+}
+}
 namespace back {
 namespace policies {
 struct thread_safety_policy__ {
@@ -1167,8 +1167,8 @@ struct thread_safe : aux::pair<thread_safety_policy__, thread_safe<TLock>> {
   }
   TLock lock;
 };
-}  // namespace policies
-}  // namespace back
+}
+}
 namespace back {
 struct no_policy : policies::thread_safety_policy__ {
   using type = no_policy;
@@ -1207,7 +1207,7 @@ struct sm_policy {
   template <class T>
   using rebind = typename rebind_impl<T, TPolicies...>::type;
 };
-}  // namespace back
+}
 namespace concepts {
 struct callable_fallback {
   void operator()();
@@ -1219,7 +1219,7 @@ aux::true_type test_callable(...);
 template <class, class T>
 struct callable
     : decltype(test_callable<aux::inherit<aux::conditional_t<__is_class(T), T, aux::none_type>, callable_fallback>>(0)) {};
-}  // namespace concepts
+}
 namespace concepts {
 template <class T>
 decltype(aux::declval<T>().operator()()) composable_impl(int);
@@ -1227,7 +1227,7 @@ template <class>
 void composable_impl(...);
 template <class T>
 struct composable : aux::is<aux::pool, decltype(composable_impl<T>(0))> {};
-}  // namespace concepts
+}
 #if !defined(BOOST_SML_DISABLE_EXCEPTIONS)
 #if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
 #define BOOST_SML_DISABLE_EXCEPTIONS true
@@ -1678,7 +1678,7 @@ class sm {
   deps_t deps_;
   sub_sms_t sub_sms_;
 };
-}  // namespace back
+}
 namespace front {
 struct operator_base {};
 struct action_base {};
@@ -1908,7 +1908,7 @@ class not_ : operator_base {
  private:
   T g;
 };
-}  // namespace front
+}
 template <class T, __BOOST_SML_REQUIRES(concepts::callable<bool, T>::value)>
 auto operator!(const T &t) {
   return front::not_<aux::zero_wrapper<T>>(aux::zero_wrapper<T>{t});
@@ -1937,8 +1937,8 @@ struct defer : action_base {
     }
   }
 };
-}  // namespace actions
-}  // namespace front
+}
+}
 using testing = back::policies::testing;
 template <class T>
 using logger = back::policies::logger<T>;
@@ -1964,7 +1964,7 @@ auto transitional_impl(T &&t) -> aux::always<typename T::dst_state, typename T::
                                              decltype(T::initial), decltype(T::history)>;
 template <class T>
 struct transitional : decltype(transitional_impl(aux::declval<T>())) {};
-}  // namespace concepts
+}
 namespace front {
 namespace actions {
 struct process {
@@ -1985,8 +1985,8 @@ struct process {
     return process_impl<TEvent>{event};
   }
 };
-}  // namespace actions
-}  // namespace front
+}
+}
 namespace front {
 template <class, class>
 struct transition_eg;
@@ -2004,7 +2004,7 @@ struct event {
   }
   auto operator()() const { return TEvent{}; }
 };
-}  // namespace front
+}
 namespace front {
 struct initial_state {};
 struct history_state {};
@@ -2097,7 +2097,7 @@ struct state_sm<T, aux::enable_if_t<concepts::composable<T>::value>> {
   using type = state<back::sm<back::sm_policy<T>>>;
 };
 #endif
-}  // namespace front
+}
 namespace front {
 struct internal {};
 template <class, class>
@@ -2547,7 +2547,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
   }
   __BOOST_SML_ZERO_SIZE_ARRAY(aux::byte);
 };
-}  // namespace front
+}
 using _ = back::_;
 #if !defined(_MSC_VER)
 template <class TEvent>
@@ -2584,7 +2584,7 @@ constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
 #endif
-}  // namespace literals
+}
 __BOOST_SML_UNUSED static front::state<back::terminate_state> X;
 __BOOST_SML_UNUSED static front::history_state H;
 __BOOST_SML_UNUSED static front::actions::defer defer;

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -87,7 +87,8 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
         process_event_noexcept<get_event_mapping_t<get_generic_t<TEvent>, mappings>>(event, deps, subs, has_exceptions{});
 #endif  // __pph__
     // Repeat internal transition until there is no more to process.
-    while(process_internal_events(anonymous{}, deps, subs)){}
+    while (process_internal_events(anonymous{}, deps, subs)) {
+    }
     process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{});
     process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{});
 
@@ -113,9 +114,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 
   template <class TDeps, class TSubs>
   void start(TDeps &deps, TSubs &subs) {
-
     process_internal_events(on_entry<_, initial>{}, deps, subs);
-    while(process_internal_events(anonymous{}, deps, subs)) {}
+    while (process_internal_events(anonymous{}, deps, subs)) {
+    }
     process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{});
   }
 
@@ -279,13 +280,12 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 #endif  // __pph__
     if (handled && defer_again_) {
       ++defer_it_;
-    }
-    else {
+    } else {
       defer_.erase(defer_it_);
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
     }
-     return handled;
+    return handled;
   }
 
   template <class TDeps, class TSubs, class TDeferQueue, class... TEvents>
@@ -304,7 +304,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
         defer_again_ = false;
       }
       defer_processing_ = false;
-     }
+    }
   }
 
   template <class TDeps, class TSubs, class... TEvents>
@@ -381,7 +381,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   process_t process_;
   defer_flag_t defer_processing_ = defer_flag_t{};
   defer_flag_t defer_again_;
-   typename defer_t::const_iterator defer_it_;
+  typename defer_t::const_iterator defer_it_;
   typename defer_t::const_iterator defer_end_;
 };
 

--- a/include/boost/sml/front/actions/defer.hpp
+++ b/include/boost/sml/front/actions/defer.hpp
@@ -17,8 +17,7 @@ struct defer : action_base {
   void operator()(const TEvent &event, TSM &sm, TDeps &, TSubs &) {
     if (sm.defer_processing_) {
       sm.defer_again_ = true;
-    }
-    else {
+    } else {
       sm.defer_.push_back(event);
     }
   }

--- a/include/boost/sml/front/transition.hpp
+++ b/include/boost/sml/front/transition.hpp
@@ -277,8 +277,9 @@ void process_internal_transitions(TDeps &, TSubs &, const TDstState &) {}
 
 template <class TDeps, class TSubs, class T>
 void process_internal_transitions(TDeps &deps, TSubs &subs, const state<back::sm<T>> &) {
-  auto& sm = back::sub_sm<back::sm_impl<T>>::get(&subs);
-  while(sm.process_internal_events(back::anonymous{}, deps, subs)) {}
+  auto &sm = back::sub_sm<back::sm_impl<T>>::get(&subs);
+  while (sm.process_internal_events(back::anonymous{}, deps, subs)) {
+  }
 }
 
 template <class S1, class S2, class E, class G, class A>

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -55,7 +55,6 @@ typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #endif  // __pph__
 
 inline namespace literals {
-
 #if !defined(_MSC_VER)  // __pph__
 template <class T, T... Chrs>
 constexpr auto operator""_s() {
@@ -67,7 +66,7 @@ constexpr auto operator""_e() {
 }
 #endif  // __pph__
 
-} // literals
+}  // literals
 
 __BOOST_SML_UNUSED static front::state<back::terminate_state> X;
 __BOOST_SML_UNUSED static front::history_state H;

--- a/test/ft/transitions.cpp
+++ b/test/ft/transitions.cpp
@@ -6,11 +6,11 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #include <boost/sml.hpp>
+#include <iostream>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 namespace sml = boost::sml;
 


### PR DESCRIPTION
Problem:
- travis is missing clang5/clang6/clang7 compilers.
- appveyor is missing MSVC 2017 Preview compiler.

Solution:
- Update travis.yml and appveyor.yml with the newest versions of available compilers.