### PR TITLE
Loop on internal, deferred and queued events, until stable state found

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1291,10 +1291,10 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
     const auto handled =
         process_event_noexcept<get_event_mapping_t<get_generic_t<TEvent>, mappings>>(event, deps, subs, has_exceptions{});
 #endif
-    while (process_internal_events(anonymous{}, deps, subs)) {
+    while (process_internal_events(anonymous{}, deps, subs)
+      | process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{})
+      | process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{})) {
     }
-    process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{});
-    process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{});
     return handled;
   }
   void initialize(const aux::type_list<> &) {}
@@ -1313,10 +1313,10 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   }
   template <class TDeps, class TSubs>
   void start(TDeps &deps, TSubs &subs) {
-    process_internal_events(on_entry<_, initial>{}, deps, subs);
-    while (process_internal_events(anonymous{}, deps, subs)) {
+    while(process_internal_events(on_entry<_, initial>{}, deps, subs)
+      | process_internal_events(anonymous{}, deps, subs)
+      | process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{})) {
     }
-    process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{});
   }
   template <class TEvent, class TDeps, class TSubs, class... Ts,
             __BOOST_SML_REQUIRES(!aux::is_base_of<get_generic_t<TEvent>, events_ids_t>::value &&
@@ -1448,7 +1448,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   }
 #endif
   template <class TDeps, class TSubs, class... TEvents>
-  void process_defer_events(TDeps &, TSubs &, const bool, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {}
+  bool process_defer_events(TDeps &, TSubs &, const bool, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {
+    return false;
+  }
   template <class TDeps, class TSubs, class TEvent>
   bool process_event_no_defer(TDeps &deps, TSubs &subs, const void *data) {
     const auto &event = *static_cast<const TEvent *>(data);
@@ -1469,8 +1471,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
     return handled;
   }
   template <class TDeps, class TSubs, class TDeferQueue, class... TEvents>
-  void process_defer_events(TDeps &deps, TSubs &subs, const bool handled, const aux::type<TDeferQueue> &,
+  bool process_defer_events(TDeps &deps, TSubs &subs, const bool handled, const aux::type<TDeferQueue> &,
                             const aux::type_list<TEvents...> &) {
+    bool processed_events = false;
     if (handled) {
       using dispatch_table_t = bool (sm_impl::*)(TDeps &, TSubs &, const void *);
       const static dispatch_table_t dispatch_table[__BOOST_SML_ZERO_SIZE_ARRAY_CREATE(sizeof...(TEvents))] = {
@@ -1479,15 +1482,19 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
       defer_again_ = false;
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
+      processed_events = defer_it_ != defer_end_;
       while (defer_it_ != defer_end_) {
         (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);
         defer_again_ = false;
       }
       defer_processing_ = false;
     }
+    return processed_events;
   }
   template <class TDeps, class TSubs, class... TEvents>
-  void process_queued_events(TDeps &, TSubs &, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {}
+  bool process_queued_events(TDeps &, TSubs &, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {
+    return false;
+  }
   template <class TDeps, class TSubs, class TEvent>
   bool process_event_no_queue(TDeps &deps, TSubs &subs, const void *data) {
     const auto &event = *static_cast<const TEvent *>(data);
@@ -1500,14 +1507,16 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 #endif
   }
   template <class TDeps, class TSubs, class TDeferQueue, class... TEvents>
-  void process_queued_events(TDeps &deps, TSubs &subs, const aux::type<TDeferQueue> &, const aux::type_list<TEvents...> &) {
+  bool process_queued_events(TDeps &deps, TSubs &subs, const aux::type<TDeferQueue> &, const aux::type_list<TEvents...> &) {
     using dispatch_table_t = bool (sm_impl::*)(TDeps &, TSubs &, const void *);
     const static dispatch_table_t dispatch_table[__BOOST_SML_ZERO_SIZE_ARRAY_CREATE(sizeof...(TEvents))] = {
         &sm_impl::process_event_no_queue<TDeps, TSubs, TEvents>...};
+    bool processed_events = !process_.empty();
     while (!process_.empty()) {
       (this->*dispatch_table[process_.front().id])(deps, subs, process_.front().data);
       process_.pop();
     }
+    return processed_events;
   }
   template <class TVisitor, class... TStates>
   void visit_current_states(const TVisitor &visitor, const aux::type_list<TStates...> &, aux::index_sequence<0>) const {

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -87,10 +87,10 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
         process_event_noexcept<get_event_mapping_t<get_generic_t<TEvent>, mappings>>(event, deps, subs, has_exceptions{});
 #endif  // __pph__
     // Repeat internal transition until there is no more to process.
-    while (process_internal_events(anonymous{}, deps, subs)) {
+    while (process_internal_events(anonymous{}, deps, subs)
+      | process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{})
+      | process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{})) {
     }
-    process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{});
-    process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{});
 
     return handled;
   }
@@ -114,10 +114,10 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 
   template <class TDeps, class TSubs>
   void start(TDeps &deps, TSubs &subs) {
-    process_internal_events(on_entry<_, initial>{}, deps, subs);
-    while (process_internal_events(anonymous{}, deps, subs)) {
+    while(process_internal_events(on_entry<_, initial>{}, deps, subs)
+      | process_internal_events(anonymous{}, deps, subs)
+      | process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{})) {
     }
-    process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{});
   }
 
   template <class TEvent, class TDeps, class TSubs, class... Ts,
@@ -266,7 +266,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 #endif  // __pph__
 
   template <class TDeps, class TSubs, class... TEvents>
-  void process_defer_events(TDeps &, TSubs &, const bool, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {}
+  bool process_defer_events(TDeps &, TSubs &, const bool, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {
+    return false;
+  }
 
   template <class TDeps, class TSubs, class TEvent>
   bool process_event_no_defer(TDeps &deps, TSubs &subs, const void *data) {
@@ -289,8 +291,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   }
 
   template <class TDeps, class TSubs, class TDeferQueue, class... TEvents>
-  void process_defer_events(TDeps &deps, TSubs &subs, const bool handled, const aux::type<TDeferQueue> &,
+  bool process_defer_events(TDeps &deps, TSubs &subs, const bool handled, const aux::type<TDeferQueue> &,
                             const aux::type_list<TEvents...> &) {
+    bool processed_events = false;
     if (handled) {
       using dispatch_table_t = bool (sm_impl::*)(TDeps &, TSubs &, const void *);
       const static dispatch_table_t dispatch_table[__BOOST_SML_ZERO_SIZE_ARRAY_CREATE(sizeof...(TEvents))] = {
@@ -299,16 +302,20 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
       defer_again_ = false;
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
+      processed_events = defer_it_ != defer_end_;
       while (defer_it_ != defer_end_) {
         (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);
         defer_again_ = false;
       }
       defer_processing_ = false;
     }
+    return processed_events;
   }
 
   template <class TDeps, class TSubs, class... TEvents>
-  void process_queued_events(TDeps &, TSubs &, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {}
+  bool process_queued_events(TDeps &, TSubs &, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {
+    return false;
+  }
 
   template <class TDeps, class TSubs, class TEvent>
   bool process_event_no_queue(TDeps &deps, TSubs &subs, const void *data) {
@@ -323,14 +330,16 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   }
 
   template <class TDeps, class TSubs, class TDeferQueue, class... TEvents>
-  void process_queued_events(TDeps &deps, TSubs &subs, const aux::type<TDeferQueue> &, const aux::type_list<TEvents...> &) {
+  bool process_queued_events(TDeps &deps, TSubs &subs, const aux::type<TDeferQueue> &, const aux::type_list<TEvents...> &) {
     using dispatch_table_t = bool (sm_impl::*)(TDeps &, TSubs &, const void *);
     const static dispatch_table_t dispatch_table[__BOOST_SML_ZERO_SIZE_ARRAY_CREATE(sizeof...(TEvents))] = {
         &sm_impl::process_event_no_queue<TDeps, TSubs, TEvents>...};
+    bool processed_events = !process_.empty();
     while (!process_.empty()) {
       (this->*dispatch_table[process_.front().id])(deps, subs, process_.front().data);
       process_.pop();
     }
+    return processed_events;
   }
 
   template <class TVisitor, class... TStates>

--- a/test/ft/actions_defer.cpp
+++ b/test/ft/actions_defer.cpp
@@ -220,3 +220,27 @@ test defer_order = [] {
   sm.process_event(event4());
   expect(sm.is(state6));
 };
+
+
+
+test defer_and_internal_process_events = [] {
+  struct c {
+    std::vector<int> calls;
+
+    auto operator()() {
+      using namespace sml;
+
+      // clang-format off
+      return make_transition_table(
+        * state1 + event<event1> / defer = state2
+        , state3 <= state2 + event<event1>
+        , X <= state3
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c, sml::defer_queue<std::deque>> sm{};
+  sm.process_event(event1{});
+  expect(sm.is(sml::X));
+};

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -138,6 +138,27 @@ test queue_process_events = [] {
   expect(2 == c_.calls[2]);
 };
 
+test queue_and_internal_process_events = [] {
+  struct c {
+    auto operator()() {
+      using namespace sml;
+
+      // clang-format off
+      return make_transition_table(
+        * idle + on_entry<sml::initial> / process(e1())
+        , s1 <= idle + event<e1>
+        , s2 <= s1
+        , s3 <= s2 / process(e1())
+        , X <= s3
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c, sml::process_queue<std::queue>> sm{};
+  expect(sm.is(sml::X));
+};
+
 test queue_process_reaction = [] {
   struct c {
     auto operator()() noexcept {


### PR DESCRIPTION
This pull request address the issue raised in #243, that internal events are not processed after a queued events. The example given there is a simple queuing of an event, which when processed should fire an internal event.

The modification in the code is to loop on internal, deferred, and queued events, until a stable state is found - i.e. no more internal, deferred, or queued events. This happens in both the `start` and `process_event` methods. The way to achieve this was to make the defer and queue processing functions to return booleans, instead of being void. This fits with `process_internal_events` already returning a boolean, and also being looped on.