### PR TITLE
Loop on internal, deferred and queued events, until stable state found

### DIFF
--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -87,10 +87,12 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
         process_event_noexcept<get_event_mapping_t<get_generic_t<TEvent>, mappings>>(event, deps, subs, has_exceptions{});
 #endif  // __pph__
     // Repeat internal transition until there is no more to process.
-    while (process_internal_events(anonymous{}, deps, subs)) {
-    }
-    process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{});
-    process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{});
+    do {
+      while (process_internal_events(anonymous{}, deps, subs)) {
+      }
+      process_defer_events(deps, subs, handled, aux::type<defer_queue_t<TEvent>>{}, events_t{});
+    } while (process_queued_events(deps, subs, aux::type<process_queue_t<TEvent>>{}, events_t{}) ||
+             process_internal_events(anonymous{}, deps, subs));
 
     return handled;
   }
@@ -115,9 +117,12 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   template <class TDeps, class TSubs>
   void start(TDeps &deps, TSubs &subs) {
     process_internal_events(on_entry<_, initial>{}, deps, subs);
-    while (process_internal_events(anonymous{}, deps, subs)) {
-    }
-    process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{});
+    do {
+      while (process_internal_events(anonymous{}, deps, subs)) {
+      }
+      process_defer_events(deps, subs, true, aux::type<defer_queue_t<initial>>{}, events_t{});
+    } while (process_queued_events(deps, subs, aux::type<process_queue_t<initial>>{}, events_t{}) ||
+             process_internal_events(anonymous{}, deps, subs));
   }
 
   template <class TEvent, class TDeps, class TSubs, class... Ts,
@@ -266,7 +271,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
 #endif  // __pph__
 
   template <class TDeps, class TSubs, class... TEvents>
-  void process_defer_events(TDeps &, TSubs &, const bool, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {}
+  bool process_defer_events(TDeps &, TSubs &, const bool, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {
+    return false;
+  }
 
   template <class TDeps, class TSubs, class TEvent>
   bool process_event_no_defer(TDeps &deps, TSubs &subs, const void *data) {
@@ -289,8 +296,9 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   }
 
   template <class TDeps, class TSubs, class TDeferQueue, class... TEvents>
-  void process_defer_events(TDeps &deps, TSubs &subs, const bool handled, const aux::type<TDeferQueue> &,
+  bool process_defer_events(TDeps &deps, TSubs &subs, const bool handled, const aux::type<TDeferQueue> &,
                             const aux::type_list<TEvents...> &) {
+    bool processed_events = false;
     if (handled) {
       using dispatch_table_t = bool (sm_impl::*)(TDeps &, TSubs &, const void *);
       const static dispatch_table_t dispatch_table[__BOOST_SML_ZERO_SIZE_ARRAY_CREATE(sizeof...(TEvents))] = {
@@ -299,16 +307,20 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
       defer_again_ = false;
       defer_it_ = defer_.begin();
       defer_end_ = defer_.end();
+      processed_events = defer_it_ != defer_end_;
       while (defer_it_ != defer_end_) {
         (this->*dispatch_table[defer_it_->id])(deps, subs, defer_it_->data);
         defer_again_ = false;
       }
       defer_processing_ = false;
     }
+    return processed_events;
   }
 
   template <class TDeps, class TSubs, class... TEvents>
-  void process_queued_events(TDeps &, TSubs &, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {}
+  bool process_queued_events(TDeps &, TSubs &, const aux::type<no_policy> &, const aux::type_list<TEvents...> &) {
+    return false;
+  }
 
   template <class TDeps, class TSubs, class TEvent>
   bool process_event_no_queue(TDeps &deps, TSubs &subs, const void *data) {
@@ -323,14 +335,16 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   }
 
   template <class TDeps, class TSubs, class TDeferQueue, class... TEvents>
-  void process_queued_events(TDeps &deps, TSubs &subs, const aux::type<TDeferQueue> &, const aux::type_list<TEvents...> &) {
+  bool process_queued_events(TDeps &deps, TSubs &subs, const aux::type<TDeferQueue> &, const aux::type_list<TEvents...> &) {
     using dispatch_table_t = bool (sm_impl::*)(TDeps &, TSubs &, const void *);
     const static dispatch_table_t dispatch_table[__BOOST_SML_ZERO_SIZE_ARRAY_CREATE(sizeof...(TEvents))] = {
         &sm_impl::process_event_no_queue<TDeps, TSubs, TEvents>...};
+    bool wasnt_empty = !process_.empty();
     while (!process_.empty()) {
       (this->*dispatch_table[process_.front().id])(deps, subs, process_.front().data);
       process_.pop();
     }
+    return wasnt_empty;
   }
 
   template <class TVisitor, class... TStates>

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -12,6 +12,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # gcc
     add_executable(test_actions_process actions_process.cpp)
     add_test(test_actions_process test_actions_process)
 
+    add_executable(test_actions_process_n_defer actions_process_n_defer.cpp)
+    add_test(test_actions_process_n_defer test_actions_process_n_defer)
+
     add_executable(test_composite composite.cpp)
     add_test(test_composite test_composite)
 

--- a/test/ft/actions_defer.cpp
+++ b/test/ft/actions_defer.cpp
@@ -220,3 +220,25 @@ test defer_order = [] {
   sm.process_event(event4());
   expect(sm.is(state6));
 };
+
+test defer_and_internal_process_events = [] {
+  struct c {
+    std::vector<int> calls;
+
+    auto operator()() {
+      using namespace sml;
+
+      // clang-format off
+      return make_transition_table(
+        * state1 + event<event1> / defer = state2
+        , state3 <= state2 + event<event1>
+        , X <= state3
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c, sml::defer_queue<std::deque>> sm{};
+  sm.process_event(event1{});
+  expect(sm.is(sml::X));
+};

--- a/test/ft/actions_process_n_defer.cpp
+++ b/test/ft/actions_process_n_defer.cpp
@@ -1,0 +1,67 @@
+#include <boost/sml.hpp>
+#include <deque>
+#include <queue>
+
+namespace sml = boost::sml;
+
+struct e1 {};
+struct e2 {};
+struct e3 {};
+
+const auto s1 = sml::state<class s1>;
+const auto s2 = sml::state<class s2>;
+const auto s3 = sml::state<class s3>;
+const auto s4 = sml::state<class s4>;
+const auto s5 = sml::state<class s5>;
+const auto s6 = sml::state<class s6>;
+const auto s7 = sml::state<class s7>;
+
+test mix_process_n_defer_at_init = [] {
+  struct c {
+    auto operator()() {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+        * s1 + on_entry<sml::initial> / process(e1{})
+        , s1 + event<e1> / defer = s2
+        , s2 / defer = s3
+        , s3 + event<e1> / process(e2{})
+        , s3 + event<e2> / defer = s4
+        , s4 + event<e2> = s5
+        , s5 = s6
+        , s6 + on_entry<_> / process(e3{})
+        , s6 + event<e3> = s7
+        , s7 = X
+      );
+      // clang-format on
+    }
+  };
+
+  sml::sm<c, sml::process_queue<std::queue>, sml::defer_queue<std::deque>> sm{};
+  expect(sm.is(sml::X));
+};
+
+test mix_process_n_defer = [] {
+  struct c {
+    auto operator()() {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+        * s1 + event<e1> / defer = s2
+        , s2 / defer = s3
+        , s3 + event<e1> / process(e2{})
+        , s3 + event<e2> / defer = s4
+        , s4 + event<e2> = s5
+        , s5 = s6
+        , s6 + on_entry<_> / process(e3{})
+        , s6 + event<e3> = s7
+        , s7 = X
+      );
+      // clang-format on
+    }
+  };  // internal, defer, process, defer, internal, process, internal
+
+  sml::sm<c, sml::process_queue<std::queue>, sml::defer_queue<std::deque>> sm{};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};


### PR DESCRIPTION
Hello again :)

This pull request address the issue raised in #243, that internal events are not processed after a queued events. The example given there is a simple queuing of an event, which when processed should fire an internal event. I added the example as a test, and three variants of the example that are more complicated.

The modification in the code is to loop on internal, deferred, and queued events, until a stable state is found - i.e. no more internal, deferred, or queued events. This happens in both the start and process_event methods. The way to achieve this was to make the queue processing function return a boolean, instead of being void. This fits with process_internal_events already returning a boolean, and also being looped on.