### PR TITLE
Remove unused cmake variable for C++11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,6 @@ endif()
 
 # c++14 required
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag(-std=c++11 HAS_CXX11_FLAG)
 check_cxx_compiler_flag(-std=c++14 HAS_CXX14_FLAG)
 check_cxx_compiler_flag(-std=c++17 HAS_CXX17_FLAG)
 


### PR DESCRIPTION
Problem:
- SML requires C++14 but still checks for whether a compiler supports
  `-std=c++11` compiler flag.

Solution:
- Remove unused CMake check and variable for detecting C++11 support.