### PR TITLE
Simplify setting -ftrack-macro-expansion=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,9 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # gcc
       INTERFACE "-Werror" # Make all warnings into errors.
       INTERFACE "-pedantic" # Issue all the warnings demanded by strict ISO C and ISO C++
       INTERFACE "-pedantic-errors" # Like -pedantic, except that errors are produced rather than warnings
+      # http://stackoverflow.com/questions/30255294/how-to-hide-extra-output-from-pragma-message
+      INTERFACE "-ftrack-macro-expansion=0"
+      INTERFACE "-fno-diagnostics-show-caret"
       )
 
     if (NOT ${SML_USE_EXCEPTIONS})
@@ -150,18 +153,13 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # gcc
         INTERFACE "-fno-exceptions" # compiles without exception support
         )
     endif()
-    if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER 4.7)
-        # http://stackoverflow.com/questions/30255294/how-to-hide-extra-output-from-pragma-message
-        target_compile_options(sml
-          INTERFACE "-ftrack-macro-expansion=0;-fno-diagnostics-show-caret")
-    endif ()
 endif ()
 
 include_directories(INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 function(add_example exe_name bm_name src_name)
   add_executable(${exe_name} ${src_name})
-  target_link_libraries(${exe_name} PUBLIC sml) 
+  target_link_libraries(${exe_name} PUBLIC sml)
   add_test(${bm_name} ${exe_name})
 endfunction()
 


### PR DESCRIPTION
Problem:
- We conditionally apply two compiler flags if the GCC min verson is
  4.7.0 or later. This conditional is unneeded since SML only supports
  GCC6 or later.

Solution:
- Remove the conditional check based on GCC version.
- Replace the compiler flags into the required set of compiler flags
  applied via `target_compile_options`.