### PR TITLE
fixed: submachine internal events aren't called if only dst

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -712,7 +712,8 @@ using get_all_events =
     aux::join_t<typename get_all_events_impl<typename Ts::src_state, typename Ts::dst_state, typename Ts::event>::type...>;
 template <class... Ts>
 using get_sub_internal_events =
-    aux::join_t<typename get_sub_internal_events_impl<typename Ts::src_state, typename Ts::event>::type...>;
+    aux::join_t<typename get_sub_internal_events_impl<typename Ts::src_state, typename Ts::event>::type...,
+                typename get_sub_internal_events_impl<typename Ts::dst_state, typename Ts::event>::type...>;
 template <class... Ts>
 using get_events = aux::type_list<typename Ts::event...>;
 template <class T>

--- a/include/boost/sml/back/utility.hpp
+++ b/include/boost/sml/back/utility.hpp
@@ -67,7 +67,8 @@ using get_all_events =
 
 template <class... Ts>
 using get_sub_internal_events =
-    aux::join_t<typename get_sub_internal_events_impl<typename Ts::src_state, typename Ts::event>::type...>;
+    aux::join_t<typename get_sub_internal_events_impl<typename Ts::src_state, typename Ts::event>::type...,
+                typename get_sub_internal_events_impl<typename Ts::dst_state, typename Ts::event>::type...>;
 
 template <class... Ts>
 using get_events = aux::type_list<typename Ts::event...>;


### PR DESCRIPTION
If a submachine appears only as a destination state of a transition, then its on_entry isn't called. This is issue #263 .

This is fixed by making sure that `get_sub_internal_events` returns the internal events aggregated from both source states and destination states of all submachines' transitions.

A test was added in `test/ft/composite.cpp`.