### PR TITLE
Fix process_event() return type from void to bool.

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1625,12 +1625,12 @@ class sm {
   sm &operator=(const sm &) = default;
   sm &operator=(sm &&) = default;
   template <class TEvent, __BOOST_SML_REQUIRES(aux::is_base_of<TEvent, events_ids>::value)>
-  void process_event(const TEvent &event) {
-    aux::get<sm_impl<TSM>>(sub_sms_).process_event(event, deps_, sub_sms_);
+  bool process_event(const TEvent &event) {
+    return aux::get<sm_impl<TSM>>(sub_sms_).process_event(event, deps_, sub_sms_);
   }
   template <class TEvent, __BOOST_SML_REQUIRES(!aux::is_base_of<TEvent, events_ids>::value)>
-  void process_event(const TEvent &event) {
-    aux::get<sm_impl<TSM>>(sub_sms_).process_event(unexpected_event<_, TEvent>{event}, deps_, sub_sms_);
+  bool process_event(const TEvent &event) {
+    return aux::get<sm_impl<TSM>>(sub_sms_).process_event(unexpected_event<_, TEvent>{event}, deps_, sub_sms_);
   }
   template <class T = aux::identity<sm_t>, class TVisitor, __BOOST_SML_REQUIRES(concepts::callable<void, TVisitor>::value)>
   void visit_current_states(const TVisitor &visitor) const {

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -450,13 +450,13 @@ class sm {
   sm &operator=(sm &&) = default;
 
   template <class TEvent, __BOOST_SML_REQUIRES(aux::is_base_of<TEvent, events_ids>::value)>
-  void process_event(const TEvent &event) {
-    aux::get<sm_impl<TSM>>(sub_sms_).process_event(event, deps_, sub_sms_);
+  bool process_event(const TEvent &event) {
+    return aux::get<sm_impl<TSM>>(sub_sms_).process_event(event, deps_, sub_sms_);
   }
 
   template <class TEvent, __BOOST_SML_REQUIRES(!aux::is_base_of<TEvent, events_ids>::value)>
-  void process_event(const TEvent &event) {
-    aux::get<sm_impl<TSM>>(sub_sms_).process_event(unexpected_event<_, TEvent>{event}, deps_, sub_sms_);
+  bool process_event(const TEvent &event) {
+    return aux::get<sm_impl<TSM>>(sub_sms_).process_event(unexpected_event<_, TEvent>{event}, deps_, sub_sms_);
   }
 
   template <class T = aux::identity<sm_t>, class TVisitor, __BOOST_SML_REQUIRES(concepts::callable<void, TVisitor>::value)>

--- a/test/ft/actions_process.cpp
+++ b/test/ft/actions_process.cpp
@@ -42,10 +42,11 @@ test process_event = [] {
   sml::sm<c, sml::process_queue<std::queue>> sm{};
   c& c_ = sm;
   expect(sm.is(idle));
-  sm.process_event(e1{});
+  expect(!sm.process_event(e4{}));
+  expect(sm.process_event(e1{}));
   expect(sm.is(s1));
   expect(!c_.a_called);
-  sm.process_event(e2{});  // + process(e3{})
+  expect(sm.process_event(e2{}));  // + process(e3{})
   expect(1 == c_.a_called);
   expect(sm.is(sml::X));
 };


### PR DESCRIPTION
The document https://boost-experimental.github.io/sml/user_guide.html
said as follows:

```cpp
template<class T> requires configurable<T>
class sm {
public:
  template<class TEvent> // no requirements
  bool process_event(const TEvent&)
```

`process_event()` returns true when handled, false otherwise.