### PR TITLE
Fix non-trivial on_entry matching

### DIFF
--- a/test/ft/actions_defer.cpp
+++ b/test/ft/actions_defer.cpp
@@ -288,5 +288,4 @@ test defer_queue_event_move_dtor = [] {
   expect(e1data2.use_count() == 1);
   expect(e1data3.use_count() == 1);
   expect(e1data4.use_count() == 1);
-
 };

--- a/test/ft/transitions.cpp
+++ b/test/ft/transitions.cpp
@@ -544,6 +544,50 @@ test initial_entry = [] {
   expect(1 == c_.entry_calls);
 };
 
+test initial_nontrivial_entry = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *idle + sml::on_entry<e2> / [] {}
+         ,idle + event<e2> = s1
+         ,s1 + on_entry<_> / [this] { ++entry_calls; }
+      );
+      // clang-format on
+    }
+
+    int entry_calls = 0;
+  };
+
+  sml::sm<c> sm{};
+  const c& c_ = sm;
+  sm.process_event(e2{});
+  expect(1 == c_.entry_calls);
+};
+
+test initial_nontrivial_exit = [] {
+  struct c {
+    auto operator()() noexcept {
+      using namespace sml;
+      // clang-format off
+      return make_transition_table(
+         *idle + sml::on_exit<_> / [this] { ++entry_calls; }
+         ,idle + event<e1> = s1
+         ,s1 + sml::on_exit<e1> / [] {}
+      );
+      // clang-format on
+    }
+
+    int entry_calls = 0;
+  };
+
+  sml::sm<c> sm{};
+  const c& c_ = sm;
+  sm.process_event(e1{});
+  expect(1 == c_.entry_calls);
+};
+
 #if !defined(_MSC_VER)
 test general_transition_overload = [] {
   struct c {


### PR DESCRIPTION
I'm on a short weekend roll :)
This pull request is about issue #294. The code in the issue was turned into a test, and also an analogous `on_exit` test.

The issue is about the matching of events. Before the fix, sml would give priority to any matching non-generic event - even if it was in an unrelated transition. But then these events would be discarded, exactly because they don't appear in the relevant transition.
The fix adds the possibility of matching the generic event in this case, exactly when the matched non-generic event isn't handled.
If it is handled, then it must have been relevant - so we don't need to try to match the generic event.