### PR TITLE
Initialize defer_again_ member with  defer_flag_t default value

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -1588,7 +1588,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   defer_t defer_;
   process_t process_;
   defer_flag_t defer_processing_ = defer_flag_t{};
-  defer_flag_t defer_again_;
+  defer_flag_t defer_again_ = defer_flag_t{};
   typename defer_t::const_iterator defer_it_;
   typename defer_t::const_iterator defer_end_;
 };

--- a/include/boost/sml/back/state_machine.hpp
+++ b/include/boost/sml/back/state_machine.hpp
@@ -406,7 +406,7 @@ struct sm_impl : aux::conditional_t<aux::is_empty<typename TSM::sm>::value, aux:
   defer_t defer_;
   process_t process_;
   defer_flag_t defer_processing_ = defer_flag_t{};
-  defer_flag_t defer_again_;
+  defer_flag_t defer_again_ = defer_flag_t{};
   typename defer_t::const_iterator defer_it_;
   typename defer_t::const_iterator defer_end_;
 };


### PR DESCRIPTION
Static code analysis has shown that the non-static class member defer_again_
is not inititialized in the constructor nor in any function that it calls.