### PR TITLE
Fix GCC 10 build

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -33,6 +33,7 @@
 #pragma clang diagnostic ignored "-Wzero-length-array"
 #elif defined(__GNUC__)
 #if !defined(__has_builtin)
+#define __BOOST_SML_DEFINED_HAS_BUILTIN
 #define __has_builtin(...) 0
 #endif
 #define __BOOST_SML_UNUSED __attribute__((unused))
@@ -44,6 +45,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #elif defined(COMPILING_WITH_MSVC)
+#define __BOOST_SML_DEFINED_HAS_BUILTIN
 #define __has_builtin(...) __has_builtin##__VA_ARGS__
 #define __has_builtin__make_integer_seq(...) 1
 #define __BOOST_SML_UNUSED
@@ -2644,10 +2646,10 @@ BOOST_SML_NAMESPACE_END
 #undef __BOOST_SML_TEMPLATE_KEYWORD
 #if defined(__clang__)
 #pragma clang diagnostic pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && defined(__BOOST_SML_DEFINED_HAS_BUILTIN)
 #undef __has_builtin
 #pragma GCC diagnostic pop
-#elif defined(COMPILING_WITH_MSVC)
+#elif defined(COMPILING_WITH_MSVC) && defined(__BOOST_SML_DEFINED_HAS_BUILTIN)
 #undef __has_builtin
 #undef __has_builtin__make_integer_seq
 #endif


### PR DESCRIPTION
See issue #337

---

Cannot build Boost.SML using GCC 10

```
In file included from /boost-sml/benchmark/complex/sml.cpp:8:
/boost-sml/include/boost/sml.hpp:2648:8: error: undefining "__has_builtin" [-Werror]
```

I'm using `gcc (GCC) 10.0.1 20200430 (Red Hat 10.0.1-0.13)` on Fedora 32. Using GCC 9 on Fedora 31 I had no problems building the project

## Full log

```
$> rm -rf BUILD-gcc-10; mkdir 'BUILD-gcc-10'; (cd BUILD-gcc-10 && cmake-amd64-gcc .. && make clean && make && make test)
-- The CXX compiler identification is GNU 10.0.1
-- Check for working CXX compiler: /usr/bin/g++
-- Check for working CXX compiler: /usr/bin/g++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test HAS_CXX14_FLAG
-- Performing Test HAS_CXX14_FLAG - Success
-- Performing Test HAS_CXX17_FLAG
-- Performing Test HAS_CXX17_FLAG - Success
-- Performing Test HAS_CXX20_FLAG
-- Performing Test HAS_CXX20_FLAG - Success
-- Found Boost: /usr/include (found version "1.69.0")  
-- Configuring done
-- Generating done
-- Build files have been written to: /boost-sml/BUILD-gcc-10
Scanning dependencies of target switch
[  1%] Building CXX object benchmark/complex/CMakeFiles/switch.dir/switch.cpp.o
[  2%] Linking CXX executable switch
[  2%] Built target switch
Scanning dependencies of target complex_sml
[  3%] Building CXX object benchmark/complex/CMakeFiles/complex_sml.dir/sml.cpp.o
In file included from /boost-sml/benchmark/complex/sml.cpp:8:
/boost-sml/include/boost/sml.hpp:2648:8: error: undefining "__has_builtin" [-Werror]
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
make[2]: *** [benchmark/complex/CMakeFiles/complex_sml.dir/build.make:83: benchmark/complex/CMakeFiles/complex_sml.dir/sml.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1381: benchmark/complex/CMakeFiles/complex_sml.dir/all] Error 2
make: *** [Makefile:161: all] Error 2
```