### PR TITLE
:wrench: [travis] Update `GCC/Clang/AppleClang` compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,13 +74,18 @@ matrix:
 
   - os: linux
     dist: trusty
-    env: CXX=clang++-7 LIBCXX=ON MEMCHECK=VALGRIND
-    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
+    env: CXX=clang++-8 MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-8", "libstdc++-8-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-8"] } }
 
   - os: linux
     dist: trusty
-    env: CXX=clang++-7 CXXSTD=c++1z LIBCXX=ON MEMCHECK=VALGRIND
-    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
+    env: CXX=clang++-8 LIBCXX=ON MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-8", "libstdc++-8-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-8"] } }
+
+  - os: linux
+    dist: trusty
+    env: CXX=clang++-8 CXXSTD=c++1z LIBCXX=ON MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["clang-8", "libstdc++-8-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-8"] } }
 
   - os: linux
     dist: trusty
@@ -107,6 +112,11 @@ matrix:
     env: CXX=g++-8 CXXSTD=c++1z MEMCHECK=VALGRIND
     addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
+  - os: linux
+    dist: trusty
+    env: CXX=g++-9 CXXSTD=c++1z MEMCHECK=VALGRIND
+    addons: { apt: { packages: ["g++-9", "libstdc++-9-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
   - os: osx
     osx_image: xcode7.3
     env: CXX=clang++
@@ -124,7 +134,15 @@ matrix:
     env: XX=clang++
 
   - os: osx
-    osx_image: xcode10.1
+    osx_image: xcode10.3
+    env: CXX=clang++
+
+  - os: osx
+    osx_image: xcode11
+    env: CXX=clang++
+
+  - os: osx
+    osx_image: xcode11.4
     env: CXX=clang++
 
 #


### PR DESCRIPTION
Problem:
- `GCC/Clang/AppleClang` compilers are out of date.

Solution:
- Add GCC-8/GCC-9/Clang-9 and xcode images 11.