### PR TITLE
:new: [example] State names visitor

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -84,4 +84,6 @@ if (IS_COMPILER_GCC_LIKE)
     add_example(testing example_testing testing.cpp)
 
     add_example(transitions example_transitions transitions.cpp)
+
+    add_example(visitor example_visitor visitor.cpp)
 endif()

--- a/example/visitor.cpp
+++ b/example/visitor.cpp
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2016-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/sml.hpp>
+#include <cassert>
+#include <iostream>
+
+namespace sml = boost::sml;
+
+struct e1 {};
+struct e2 {};
+struct e3 {};
+struct e4 {};
+struct e5 {};
+
+struct sub {
+  auto operator()() const {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+     *"idle"_s + event<e3> = "sub1"_s
+    , "sub1"_s + event<e4> = X
+    );
+    // clang-format on
+  }
+};
+
+struct composite {
+  auto operator()() const {
+    using namespace sml;
+    // clang-format off
+    return make_transition_table(
+     *"idle"_s   + event<e1> = "s1"_s
+    , "s1"_s     + event<e2> = state<sub>
+    , state<sub> + event<e5> = X
+    );
+    // clang-format on
+  }
+};
+
+template <class TSM>
+class state_name_visitor {
+ public:
+  explicit state_name_visitor(const TSM& sm) : sm_{sm} {}
+
+  template <class TSub>
+  void operator()(boost::sml::aux::string<boost::sml::sm<TSub>>) const {
+    std::cout << boost::sml::aux::get_type_name<TSub>() << ':';
+    sm_.template visit_current_states<boost::sml::aux::identity<TSub>>(*this);
+  }
+
+  template <class TState>
+  void operator()(TState state) const {
+    std::cout << state.c_str() << '\n';
+  }
+
+ private:
+  const TSM& sm_;
+};
+
+int main() {
+  sml::sm<composite> sm{};
+
+  const auto state_name = state_name_visitor<decltype(sm)>{sm};
+
+  sm.process_event(e1{});
+  sm.visit_current_states(state_name);  // s1
+
+  sm.process_event(e2{});
+  sm.visit_current_states(state_name);  // sub:idle
+
+  sm.process_event(e3{});
+  sm.visit_current_states(state_name);  // sub:sub1
+
+  sm.process_event(e4{});
+  sm.visit_current_states(state_name);  // sub:terminate
+
+  sm.process_event(e5{});
+  sm.visit_current_states(state_name);  // terminate
+}

--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -338,7 +338,7 @@ struct missing_ctor_parameter {
   operator U() {
     return {};
   }
-#if !defined(_MSC_VER) && !defined(__clang__)
+#if !(defined(_MSC_VER) && !defined(__clang__))
   template <class TMissing, __BOOST_SML_REQUIRES(!aux::is_base_of<pool_type_base, TMissing>::value)>
   operator TMissing &() const {
     static_assert(missing_ctor_parameter<TMissing>::value,
@@ -2589,7 +2589,7 @@ struct transition<state<internal>, state<S2>, front::event<E>, always, none> {
 };
 }
 using _ = back::_;
-#if !defined(_MSC_VER) && !defined(__clang__)
+#if !(defined(_MSC_VER) && !defined(__clang__))
 template <class TEvent>
 constexpr front::event<TEvent> event{};
 #else
@@ -2606,7 +2606,7 @@ template <class T>
 front::event<back::exception<T>> exception __BOOST_SML_VT_INIT;
 using anonymous = back::anonymous;
 using initial = back::initial;
-#if !defined(_MSC_VER) && !defined(__clang__)
+#if !(defined(_MSC_VER) && !defined(__clang__))
 template <class T>
 constexpr typename front::state_sm<T>::type state{};
 #else
@@ -2614,7 +2614,7 @@ template <class T>
 typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #endif
 inline namespace literals {
-#if !defined(_MSC_VER) && !defined(__clang__)
+#if !(defined(_MSC_VER) && !defined(__clang__))
 template <class T, T... Chrs>
 constexpr auto operator""_s() {
   return front::state<aux::string<T, Chrs...>>{};

--- a/include/boost/sml/aux_/utility.hpp
+++ b/include/boost/sml/aux_/utility.hpp
@@ -160,7 +160,7 @@ struct missing_ctor_parameter {
     return {};
   }
 
-#if !defined(_MSC_VER) && !defined(__clang__)  // __pph__
+#if !(defined(_MSC_VER) && !defined(__clang__))  // __pph__
   template <class TMissing, __BOOST_SML_REQUIRES(!aux::is_base_of<pool_type_base, TMissing>::value)>
   operator TMissing &() const {
     static_assert(missing_ctor_parameter<TMissing>::value,

--- a/include/boost/sml/back/policies/testing.hpp
+++ b/include/boost/sml/back/policies/testing.hpp
@@ -13,7 +13,6 @@ namespace back {
 namespace policies {
 
 struct testing_policy__ {};
-
 struct testing : aux::pair<testing_policy__, testing> {};
 
 }  // namespace policies

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -21,7 +21,7 @@ using _ = back::_;
 
 /// events
 
-#if !defined(_MSC_VER) && !defined(__clang__)  // __pph__
+#if !(defined(_MSC_VER) && !defined(__clang__))  // __pph__
 template <class TEvent>
 constexpr front::event<TEvent> event{};
 #else   // __pph__
@@ -46,7 +46,7 @@ using initial = back::initial;
 
 /// states
 
-#if !defined(_MSC_VER) && !defined(__clang__)  // __pph__
+#if !(defined(_MSC_VER) && !defined(__clang__))  // __pph__
 template <class T>
 constexpr typename front::state_sm<T>::type state{};
 #else   // __pph__
@@ -55,7 +55,7 @@ typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #endif  // __pph__
 
 inline namespace literals {
-#if !defined(_MSC_VER) && !defined(__clang__)  // __pph__
+#if !(defined(_MSC_VER) && !defined(__clang__))  // __pph__
 template <class T, T... Chrs>
 constexpr auto operator""_s() {
   return front::state<aux::string<T, Chrs...>>{};


### PR DESCRIPTION
Problem:
- There is no example showig how to print state names using a visitor.
- There is no easy support to print sub State Machines state names.

Solution:
- Add example to print state names using a custom visitor and a composite State Machine.