### PR TITLE
:new: :arrow_up: [NTTP] Support for `""_s` using C++20 `non-type temp…

### DIFF
--- a/include/boost/sml/aux_/utility.hpp
+++ b/include/boost/sml/aux_/utility.hpp
@@ -315,6 +315,22 @@ const char *get_type_name() {
 #endif                    // __pph__
 }
 
+#if defined(__cpp_nontype_template_parameter_class)  // __pph__
+template <auto N>
+struct fixed_string {
+  static constexpr auto size = N;
+  char data[N + 1]{};
+
+  constexpr fixed_string(char const *str) {
+    for (auto i = 0; i < N; ++i) {
+      data[i] = str[i];
+    }
+  }
+};
+template <auto N>
+fixed_string(char const (&)[N]) -> fixed_string<N - 1>;
+#endif  // __pph__
+
 template <class T, T...>
 struct string;
 

--- a/include/boost/sml/transition_table.hpp
+++ b/include/boost/sml/transition_table.hpp
@@ -55,7 +55,18 @@ typename front::state_sm<T>::type state __BOOST_SML_VT_INIT;
 #endif  // __pph__
 
 inline namespace literals {
-#if !(defined(_MSC_VER) && !defined(__clang__))  // __pph__
+#if defined(__cpp_nontype_template_parameter_class)  // __pph__
+template <aux::fixed_string Str>
+constexpr auto operator""_s() {
+  return []<auto... Ns>(aux::index_sequence<Ns...>) { return front::state<aux::string<char, Str.data[Ns]...>>{}; }
+  (aux::make_index_sequence<Str.size>{});
+}
+template <aux::fixed_string Str>
+constexpr auto operator""_e() {
+  return []<auto... Ns>(aux::index_sequence<Ns...>) { return event<aux::string<char, Str.data[Ns]...>>; }
+  (aux::make_index_sequence<Str.size>{});
+}
+#elif !(defined(_MSC_VER) && !defined(__clang__))  // __pph__
 template <class T, T... Chrs>
 constexpr auto operator""_s() {
   return front::state<aux::string<T, Chrs...>>{};
@@ -64,8 +75,7 @@ template <class T, T... Chrs>
 constexpr auto operator""_e() {
   return event<aux::string<T, Chrs...>>;
 }
-#endif  // __pph__
-
+#endif                                             // __pph__
 }  // literals
 
 __BOOST_SML_UNUSED static front::state<back::terminate_state> X;


### PR DESCRIPTION
…late parameters`

Problem:
- ""_s is using a GNU extension to produce an aux::string.

Solution:
- C++20 `non-type template parameters` instead if available.

Note:
- That makes SML C++20 standard compliant.