### PR TITLE
Fix bug in dep resolution when requesting a "const T*"

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -207,6 +207,16 @@ struct remove_reference<T &&> {
 };
 template <class T>
 using remove_reference_t = typename remove_reference<T>::type;
+template <class T>
+struct remove_pointer {
+  using type = T;
+};
+template <class T>
+struct remove_pointer<T *> {
+  using type = T;
+};
+template <class T>
+using remove_pointer_t = typename remove_pointer<T>::type;
 }
 namespace aux {
 using swallow = int[];
@@ -363,6 +373,14 @@ template <class T>
 T &try_get(const pool_type<T &> *object) {
   return object->value;
 }
+template <class T>
+const T *try_get(const pool_type<const T *> *object) {
+  return object->value;
+}
+template <class T>
+T *try_get(const pool_type<T *> *object) {
+  return object->value;
+}
 template <class T, class TPool>
 T &get(TPool &p) {
   return static_cast<pool_type<T> &>(p).value;
@@ -371,13 +389,21 @@ template <class T, class TPool>
 const T &cget(const TPool &p) {
   return static_cast<const pool_type<T> &>(p).value;
 }
+template <class T, class TPool>
+T *get(TPool *p) {
+  return static_cast<pool_type<T> &>(p).value;
+}
+template <class T, class TPool>
+const T *cget(const TPool *p) {
+  return static_cast<const pool_type<T> &>(p).value;
+}
 template <class... Ts>
 struct pool : pool_type<Ts>... {
   using boost_di_inject__ = type_list<Ts...>;
   pool() = default;
   explicit pool(Ts... ts) : pool_type<Ts>(ts)... {}
   template <class... TArgs>
-  pool(init, const pool<TArgs...> &p) : pool_type<Ts>(try_get<aux::remove_const_t<aux::remove_reference_t<Ts>>>(&p))... {}
+  pool(init, const pool<TArgs...> &p) : pool_type<Ts>(try_get<aux::remove_const_t<aux::remove_reference_t<aux::remove_pointer_t<Ts>>>>(&p))... {}
   template <class... TArgs>
   pool(const pool<TArgs...> &p) : pool_type<Ts>(init{}, p)... {}
 };

--- a/test/ft/dependencies.cpp
+++ b/test/ft/dependencies.cpp
@@ -142,6 +142,90 @@ test dependencies_smart_ptrs = [] {
   expect(sm.is(sml::X));
 };
 
+test dependencies_with_reference = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](Data& data) { expect(data.m_member == 42); };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test dependencies_with_const_reference = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](const Data& data) {
+        expect(data.m_member == 42);
+      };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test dependencies_with_pointer = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](Data* data) { expect(data->m_member == 42); };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{&data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
+test dependencies_with_const_pointer = [] {
+  struct Data {
+    int m_member { 42 };
+  };
+
+  struct c {
+    auto operator()() noexcept {
+      const auto action = [](const Data* data) {
+        expect(data->m_member == 42);
+      };
+
+      using namespace sml;
+      return make_transition_table(*idle + event<e1> / action = X);
+    }
+  };
+
+  Data data;
+  sml::sm<c> sm{&data};
+  sm.process_event(e1{});
+  expect(sm.is(sml::X));
+};
+
 #if (_MSC_VER >= 1910)  // MSVC 2017
 test dependencies_multiple_subs = [] {
   struct update {


### PR DESCRIPTION
Hello,
I have fixed a bug in dependency resolution when requesting a "const T*" after injecting a "T*" as dependency. 

Before this fix, if a T* was injected as dependency, requesting a const T* will result in a invalid nullptr.
The dependency resolution of objects passed by reference is not affected by this problem.

I have added four tests: 
- dependencies_with_reference
- dependencies_with_const_reference
- dependencies_with_pointer
- dependencies_with_const_pointer (this test fails without the fix)

I am new to TMP and this is my first contribute in general so I hope I didn't do anything wrong. 
