### PR TITLE
Do not emit a zero sized array for GCC

### DIFF
--- a/include/boost/sml.hpp
+++ b/include/boost/sml.hpp
@@ -36,7 +36,7 @@
 #define __BOOST_SML_UNUSED __attribute__((unused))
 #define __BOOST_SML_VT_INIT \
   {}
-#define __BOOST_SML_ZERO_SIZE_ARRAY(...) __VA_ARGS__ _[0]
+#define __BOOST_SML_ZERO_SIZE_ARRAY(...)
 #define __BOOST_SML_ZERO_SIZE_ARRAY_CREATE(...) __VA_ARGS__ ? __VA_ARGS__ : 1
 #define __BOOST_SML_TEMPLATE_KEYWORD template
 #pragma GCC diagnostic push


### PR DESCRIPTION
When emitting a zero sized array, GCC 10.1 fails compilation for certain state machines with the warning that subscript 1 is accessed.

However when using the same code as for MSVC (not emitting a zero sized array), no such warning es emitted.

Therefore I propose to not emit a zero sized array.

Note: GCC 9, Clang 9 as well as Clang 10 compile the same state machine without any errors or warnings.